### PR TITLE
Add whole-assignment attempt policy

### DIFF
--- a/app/Assignment.php
+++ b/app/Assignment.php
@@ -174,7 +174,8 @@ class Assignment extends Model
             'release_assignment_contacted_instructors',
             'rubric_points_breakdowns',
             'maximum_number_of_allowed_attempts_notifications',
-            'submitted_work_pending_scores'
+            'submitted_work_pending_scores',
+            'mastery_assignment_attempts'
         ];
 
         foreach ($tables as $table) {
@@ -906,6 +907,15 @@ class Assignment extends Model
             ->first()) {
             return true;
         }
+        if (DB::table('mastery_assignment_attempts')
+            ->join('users', 'mastery_assignment_attempts.user_id', 'users.id')
+            ->where('assignment_id', $this->id)
+            ->where('fake_student', 0)
+            ->where('formative_student', 0)
+            ->where('role', 3)
+            ->first()) {
+            return true;
+        }
         return false;
     }
 
@@ -1309,7 +1319,16 @@ class Assignment extends Model
             ->where('role', 3)
             ->get()
             ->isNotEmpty();
-        return $submission_files_not_empty || $submissions_not_empty;
+        $mastery_attempts_not_empty = DB::table('mastery_assignment_attempts')
+            ->join('assignments', 'mastery_assignment_attempts.assignment_id', '=', 'assignments.id')
+            ->join('users', 'mastery_assignment_attempts.user_id', '=', 'users.id')
+            ->whereIn('mastery_assignment_attempts.assignment_id', $assignment_ids)
+            ->where('assignments.mastery_retake_enabled', 1)
+            ->where('fake_student', 0)
+            ->where('formative_student', 0)
+            ->where('role', 3)
+            ->exists();
+        return $submission_files_not_empty || $submissions_not_empty || $mastery_attempts_not_empty;
 
 
     }
@@ -1391,7 +1410,8 @@ class Assignment extends Model
         foreach (['submission_score_overrides',
                      'review_histories',
                      'assignment_question_time_on_tasks',
-                     'randomized_assignment_questions'] as $table) {
+                     'randomized_assignment_questions',
+                     'mastery_assignment_attempts'] as $table) {
             DB::table($table)->where('user_id', $user->id)->whereIn('assignment_id', $assignments_to_remove_ids)->delete();
         }
     }

--- a/app/Course.php
+++ b/app/Course.php
@@ -95,6 +95,7 @@ class Course extends Model
 
         DB::table('submissions')->whereIn('assignment_id', $assignment_ids)->delete();
         DB::table('submission_files')->whereIn('assignment_id', $assignment_ids)->delete();
+        DB::table('mastery_assignment_attempts')->whereIn('assignment_id', $assignment_ids)->delete();
         DB::table('scores')->whereIn('assignment_id', $assignment_ids)->delete();
         DB::table('cutups')->whereIn('assignment_id', $assignment_ids)->delete();
         DB::table('seeds')->whereIn('assignment_id', $assignment_ids)->delete();

--- a/app/Exceptions/MasteryRetakeConflictException.php
+++ b/app/Exceptions/MasteryRetakeConflictException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class MasteryRetakeConflictException extends RuntimeException
+{
+    private $reason;
+
+    /**
+     * Create a conflict with a stable reason code for API clients.
+     */
+    public function __construct(string $reason, string $message)
+    {
+        parent::__construct($message);
+        $this->reason = $reason;
+    }
+
+    /**
+     * Return the machine-readable reason for the rejected lifecycle action.
+     */
+    public function reason(): string
+    {
+        return $this->reason;
+    }
+}

--- a/app/Http/Controllers/AssignmentController.php
+++ b/app/Http/Controllers/AssignmentController.php
@@ -1963,6 +1963,7 @@ class AssignmentController extends Controller
                 'question_view' => $request->hasCookie('question_view') ? $request->cookie('question_view') : 'basic',
                 'name' => $assignment->name,
                 'algorithmic' => $assignment->algorithmic,
+                'mastery_retake_enabled' => (bool)$assignment->mastery_retake_enabled,
                 'is_anonymous_user' => $request->user()->email === 'anonymous' && $assignment->course->user_id !== $request->user()->id,
                 'assessment_type' => $assignment->assessment_type,
                 'formative' => $assignment->formative,

--- a/app/Http/Controllers/AssignmentSyncQuestionController.php
+++ b/app/Http/Controllers/AssignmentSyncQuestionController.php
@@ -8,6 +8,7 @@ use App\DiscussionComment;
 use App\DiscussionGroup;
 use App\Enrollment;
 use App\Exceptions\Handler;
+use App\Exceptions\MasteryRetakeConflictException;
 use App\Forge;
 use App\ForgeAssignmentQuestion;
 use App\ForgeSettings;
@@ -27,6 +28,7 @@ use App\RandomizedAssignmentQuestion;
 use App\ReportToggle;
 use App\RubricPointsBreakdown;
 use App\Solution;
+use App\Services\MasteryAssignmentAttemptService;
 use App\Traits\LibretextFiles;
 use App\Traits\Seed;
 use App\Traits\Statistics;
@@ -1443,6 +1445,11 @@ class AssignmentSyncQuestionController extends Controller
             return $response;
         }
 
+        if ($this->masteryQuestionConfigurationIsLocked($assignment)) {
+            $response['message'] = 'Questions cannot be added after a student has started a whole-assignment attempt.';
+            return $response;
+        }
+
         if ($assignment->cannotAddOrRemoveQuestionsForQuestionWeightAssignment()) {
             $response['message'] = "You cannot access the remixer since there are already submissions and this assignment computes points using question weights.";
             return $response;
@@ -2648,6 +2655,10 @@ class AssignmentSyncQuestionController extends Controller
             $response['message'] = $authorized->message();
             return $response;
         }
+        if ($this->masteryQuestionConfigurationIsLocked($assignment)) {
+            $response['message'] = 'Question response settings cannot be changed after a student has started a whole-assignment attempt.';
+            return $response;
+        }
         try {
             $assignment_ids = [$assignment->id];
             if ($assignment->course->alpha) {
@@ -2775,6 +2786,11 @@ class AssignmentSyncQuestionController extends Controller
             return $response;
         }
 
+        if ($this->masteryQuestionConfigurationIsLocked($assignment)) {
+            $response['message'] = 'Question points cannot be changed after a student has started a whole-assignment attempt.';
+            return $response;
+        }
+
 
         $assignment_ids = [$assignment->id];
         if ($assignment->course->alpha) {
@@ -2832,6 +2848,10 @@ class AssignmentSyncQuestionController extends Controller
 
         if (!$authorized->allowed()) {
             $response['message'] = $authorized->message();
+            return $response;
+        }
+        if ($this->masteryQuestionConfigurationIsLocked($assignment)) {
+            $response['message'] = 'Question weights cannot be changed after a student has started a whole-assignment attempt.';
             return $response;
         }
         $is_randomized_assignment = $assignment->number_of_randomized_assessments;
@@ -2893,6 +2913,10 @@ class AssignmentSyncQuestionController extends Controller
             $response['message'] = $authorized->message();
             return $response;
         }
+        if ($this->masteryQuestionConfigurationIsLocked($assignment)) {
+            $response['message'] = 'Questions cannot be added after a student has started a whole-assignment attempt.';
+            return $response;
+        }
         if ($assignment->cannotAddOrRemoveQuestionsForQuestionWeightAssignment()) {
             $response['message'] = "You cannot add a question since there are already submissions and this assignment computes points using question weights.";
             return $response;
@@ -2934,6 +2958,11 @@ class AssignmentSyncQuestionController extends Controller
 
         if (!$authorized->allowed()) {
             $response['message'] = $authorized->message();
+            return $response;
+        }
+
+        if ($this->masteryQuestionConfigurationIsLocked($assignment)) {
+            $response['message'] = 'Questions cannot be removed after a student has started a whole-assignment attempt.';
             return $response;
         }
 
@@ -3318,7 +3347,8 @@ class AssignmentSyncQuestionController extends Controller
                                 Question                $Question,
                                 Solution                $solution,
                                 PendingQuestionRevision $pendingQuestionRevision,
-                                IMathAS                 $IMathAS): array
+                                IMathAS                 $IMathAS,
+                                MasteryAssignmentAttemptService $masteryAttemptService): array
     {
 
 
@@ -3422,6 +3452,22 @@ class AssignmentSyncQuestionController extends Controller
                     $clicker_time_left[$question->question_id] = $num_seconds;
                 }
 
+            }
+            $mastery_attempt = null;
+            $response['mastery_attempt'] = null;
+            if ($masteryAttemptService->enabled($assignment) && $request->user()->role === 3) {
+                try {
+                    $mastery_attempt = $masteryAttemptService->getOrCreateForLaunch(
+                        $assignment,
+                        $request->user(),
+                        array_values($question_ids)
+                    );
+                    $response['mastery_attempt'] = $masteryAttemptService->payload($mastery_attempt);
+                } catch (MasteryRetakeConflictException $e) {
+                    $response['reason'] = $e->reason();
+                    $response['message'] = $e->getMessage();
+                    return $response;
+                }
             }
             $question_info = DB::table('questions')
                 ->select('*')
@@ -3985,6 +4031,9 @@ class AssignmentSyncQuestionController extends Controller
                 $assignment->questions[$key]['notes'] = Auth::user()->role === 2 ? $question->addTimeToS3Files($assignment->questions[$key]->notes, $domd) : null;
 
                 $custom_claims = [];
+                if ($mastery_attempt) {
+                    $custom_claims['mastery_attempt_id'] = $mastery_attempt->id;
+                }
                 if ($question->technology === 'imathas' && isset($submissions_by_question_id[$question->id])) {
                     $custom_claims['stuanswers'] = $Submission->getStudentResponse($submissions_by_question_id[$question->id], 'imathas');
 
@@ -4093,6 +4142,11 @@ class AssignmentSyncQuestionController extends Controller
 
             $response['type'] = 'success';
             $response['questions'] = $assignment->questions->values();
+            if ($mastery_attempt) {
+                $response['mastery_attempt'] = $masteryAttemptService->payload(
+                    $masteryAttemptService->latestAttempt($assignment, $request->user())
+                );
+            }
             $end_time = microtime(true);
             $execution_time = ($end_time - $start_time);
             DB::table('execution_times')->insert([
@@ -4281,6 +4335,10 @@ class AssignmentSyncQuestionController extends Controller
                 $response['message'] = $authorized->message();
                 return $response;
             }
+            if ($this->masteryQuestionConfigurationIsLocked($assignment)) {
+                $response['message'] = 'Question revisions cannot be changed after a student has started a whole-assignment attempt.';
+                return $response;
+            }
             if (!$request->understand_student_submissions_removed) {
                 $response['message'] = "You must confirm that you understand that student submissions will be removed.";
                 return $response;
@@ -4327,6 +4385,16 @@ class AssignmentSyncQuestionController extends Controller
         return $response;
 
 
+    }
+
+    /**
+     * Keep an active attempt's question snapshot stable after real student work begins.
+     */
+    private
+    function masteryQuestionConfigurationIsLocked(Assignment $assignment): bool
+    {
+        return (bool)$assignment->mastery_retake_enabled
+            && app(MasteryAssignmentAttemptService::class)->hasRealStudentAttempts($assignment);
     }
 
     private

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -2174,6 +2174,7 @@ class CourseController extends Controller
                 'maximum_number_of_allowed_attempts_notifications',
                 'submitted_works',
                 'submitted_work_pending_scores',
+                'mastery_assignment_attempts',
                 'h5p_activity_sets'];
             foreach ($tables as $table) {
                 DB::table($table)->whereIn('assignment_id', $assignment_ids)->delete();

--- a/app/Http/Controllers/JWTController.php
+++ b/app/Http/Controllers/JWTController.php
@@ -8,11 +8,13 @@ use App\AssignmentSyncQuestion;
 use App\CanGiveUp;
 use App\DataShop;
 use App\Exceptions\Handler;
+use App\Exceptions\MasteryRetakeConflictException;
 use App\Http\Requests\StoreSubmission;
 use App\JWE;
 use App\LearningTree;
 use App\LearningTreeNodeSubmission;
 use App\Score;
+use App\Services\MasteryAssignmentAttemptService;
 use App\Submission;
 use App\UnconfirmedSubmission;
 use App\User;
@@ -155,6 +157,17 @@ class JWTController extends Controller
                 throw new Exception($problemJWT->adapt->technology . " is not an accepted technology.  Please contact us for assistance.");
             }
 
+            $callback_assignment = Assignment::find($problemJWT->adapt->assignment_id);
+            $callback_user = User::find($problemJWT->sub);
+            if ($callback_assignment && $callback_assignment->mastery_retake_enabled) {
+                app(MasteryAssignmentAttemptService::class)->validateSubmission(
+                    $callback_assignment,
+                    $callback_user,
+                    $problemJWT->adapt->mastery_attempt_id ?? null,
+                    (int)$problemJWT->adapt->question_id
+                );
+            }
+
             if ($problemJWT->adapt->technology === 'webwork' && isset($answerJWT->score['answers'])) {
                 $answers = $answerJWT->score['answers'];
                 foreach ($answers as $value) {
@@ -190,6 +203,7 @@ class JWTController extends Controller
             $request['assignment_id'] = $problemJWT->adapt->assignment_id;
             $request['question_id'] = $problemJWT->adapt->question_id;
             $request['technology'] = $problemJWT->adapt->technology;
+            $request['mastery_attempt_id'] = $problemJWT->adapt->mastery_attempt_id ?? null;
             $request['learning_tree_id'] = $problemJWT->adapt->learning_tree_id ?? null;
             $request['branch_id'] = $problemJWT->adapt->branch_id ?? null;
             //nothing to be saved since this is a learning tree assignment and it's part of a remediation
@@ -225,6 +239,12 @@ class JWTController extends Controller
             }
             return $Submission->store($request, new Submission(), new Assignment(), new Score(), new DataShop(), new AssignmentSyncQuestion());
 
+        } catch (MasteryRetakeConflictException $e) {
+            return response()->json([
+                'type' => 'error',
+                'reason' => $e->reason(),
+                'message' => $e->getMessage()
+            ], 409);
         } catch (Exception $e) {
             if ($log_exception) {
                 $h = new Handler(app());

--- a/app/Http/Controllers/MasteryAssignmentAttemptController.php
+++ b/app/Http/Controllers/MasteryAssignmentAttemptController.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Assignment;
+use App\Exceptions\Handler;
+use App\Exceptions\MasteryRetakeConflictException;
+use App\Services\MasteryAssignmentAttemptService;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Log;
+
+class MasteryAssignmentAttemptController extends Controller
+{
+    /**
+     * Start or idempotently return the next whole-assignment attempt for a student.
+     */
+    public function store(
+        Request $request,
+        Assignment $assignment,
+        MasteryAssignmentAttemptService $attemptService
+    ): JsonResponse {
+        $authorized = Gate::inspect('view', $assignment);
+        if (!$authorized->allowed() || $request->user()->role !== 3) {
+            return response()->json([
+                'type' => 'error',
+                'reason' => 'not_authorized',
+                'message' => 'You are not authorized to start this assignment attempt.'
+            ], 403);
+        }
+
+        $validated = $request->validate([
+            'previous_attempt_id' => 'required|integer|min:1'
+        ]);
+
+        try {
+            $result = $attemptService->startNextAttempt(
+                $assignment,
+                $request->user(),
+                (int)$validated['previous_attempt_id']
+            );
+
+            return response()->json([
+                'type' => 'success',
+                'message' => $result['already_started']
+                    ? 'That assignment attempt has already started.'
+                    : 'A new assignment attempt is ready.',
+                'already_started' => $result['already_started'],
+                'mastery_attempt' => $attemptService->payload($result['attempt'])
+            ]);
+        } catch (MasteryRetakeConflictException $e) {
+            Log::warning('mastery_attempt.retake_rejected', [
+                'assignment_id' => $assignment->id,
+                'user_id' => $request->user()->id,
+                'previous_attempt_id' => $validated['previous_attempt_id'],
+                'reason' => $e->reason()
+            ]);
+            return response()->json([
+                'type' => 'error',
+                'reason' => $e->reason(),
+                'message' => $e->getMessage()
+            ], 409);
+        } catch (Exception $e) {
+            $handler = new Handler(app());
+            $handler->report($e);
+            return response()->json([
+                'type' => 'error',
+                'reason' => 'retake_failed',
+                'message' => 'A new assignment attempt could not be prepared. Your completed attempt was not changed. Please try again.'
+            ], 500);
+        }
+    }
+}

--- a/app/Http/Controllers/SectionController.php
+++ b/app/Http/Controllers/SectionController.php
@@ -87,6 +87,10 @@ class SectionController extends Controller
             foreach ($course->assignments as $assignment) {
                 $assignment->scores()->whereIn('user_id', $enrolled_user_ids)->delete();
                 $assignment->seeds()->whereIn('user_id', $enrolled_user_ids)->delete();
+                DB::table('mastery_assignment_attempts')
+                    ->where('assignment_id', $assignment->id)
+                    ->whereIn('user_id', $enrolled_user_ids)
+                    ->delete();
                 $submission->where('assignment_id', $assignment->id)
                     ->whereIn('user_id', $enrolled_user_ids)
                     ->delete();

--- a/app/Http/Controllers/UnconfirmedSubmissionController.php
+++ b/app/Http/Controllers/UnconfirmedSubmissionController.php
@@ -86,7 +86,9 @@ class UnconfirmedSubmissionController extends Controller
                 return $response;
             }
             $unconfirmed_submission = $unconfirmed_submission->toArray();
-            $unconfirmed_submission['submission'] = json_decode($unconfirmed_submission['submission'], 1)['submission'];
+            $stored_request = json_decode($unconfirmed_submission['submission'], true);
+            $unconfirmed_submission['submission'] = $stored_request['submission'];
+            $unconfirmed_submission['mastery_attempt_id'] = $stored_request['mastery_attempt_id'] ?? null;
             $unconfirmed_submission['technology'] = 'webwork';
             $Submission = new Submission();
             return $Submission->store(new StoreSubmission($unconfirmed_submission),

--- a/app/Http/Requests/StoreAssignmentProperties.php
+++ b/app/Http/Requests/StoreAssignmentProperties.php
@@ -19,6 +19,8 @@ use App\Rules\IsValidPeriodOfTime;
 use App\Rules\IsADateLaterThan;
 use App\Rules\IsValidAssesmentTypeForScoringType;
 use App\Rules\SubmittedWorkFormatRule;
+use App\Services\MasteryAssignmentAttemptService;
+use App\Services\MasteryRetakeEligibility;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -47,6 +49,12 @@ class StoreAssignmentProperties extends FormRequest
      */
     protected function prepareForValidation(): void
     {
+        if (!$this->has('mastery_retake_enabled')) {
+            $this->merge(['mastery_retake_enabled' => 0]);
+        }
+        if (!$this->has('mastery_number_of_allowed_attempts')) {
+            $this->merge(['mastery_number_of_allowed_attempts' => 'unlimited']);
+        }
         if ($this->assessment_type !== 'flashcard') {
             $this->merge(['flashcard_settings' => null]);
         }
@@ -77,6 +85,11 @@ class StoreAssignmentProperties extends FormRequest
                 'default_open_ended_submission_type' => Rule::in(['file', 'rich text', 'audio', 0]),
                 'notifications' => Rule::in([0, 1]),
                 'formative' => Rule::in([0, 1]),
+                'mastery_retake_enabled' => Rule::in([0, 1]),
+                'mastery_number_of_allowed_attempts' => [
+                    'required_if:mastery_retake_enabled,1',
+                    new IsValidNumberOfAllowedAttempts()
+                ],
                 'can_contact_instructor_auto_graded' => Rule::in(['always', 'before submission', 'before due date', 'after due date', 'never'])
             ];
             if (!$formative) {
@@ -242,6 +255,52 @@ class StoreAssignmentProperties extends FormRequest
             }
         }
         return $rules;
+    }
+
+    /**
+     * Apply whole-assignment attempt eligibility and student-work locks after field validation.
+     */
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            $assignment = $this->route('assignment');
+            if (!($assignment instanceof Assignment)) {
+                $assignment = new Assignment();
+            }
+
+            if ($assignment->exists
+                && app(MasteryAssignmentAttemptService::class)->hasRealStudentAttempts($assignment)
+                && (bool)$assignment->mastery_retake_enabled !== (bool)$this->mastery_retake_enabled) {
+                $validator->errors()->add(
+                    'mastery_retake_enabled',
+                    'Whole-assignment attempts cannot be enabled or disabled after a student attempt exists.'
+                );
+                return;
+            }
+
+            if ($assignment->exists
+                && !(bool)$assignment->mastery_retake_enabled
+                && (bool)$this->mastery_retake_enabled
+                && $assignment->hasNonFakeStudentFileOrQuestionSubmissions()) {
+                $validator->errors()->add(
+                    'mastery_retake_enabled',
+                    'Whole-assignment attempts cannot be enabled after student work exists.'
+                );
+                return;
+            }
+
+            if (!(bool)$this->mastery_retake_enabled) {
+                return;
+            }
+
+            $overrides = $this->all();
+            $eligibility = app(MasteryRetakeEligibility::class)
+                ->evaluate($assignment, $overrides, false);
+            foreach ($eligibility->reasons() as $reason) {
+                $validator->errors()->add('mastery_retake_enabled', $reason['message']);
+            }
+
+        });
     }
 
     /**

--- a/app/MasteryAssignmentAttempt.php
+++ b/app/MasteryAssignmentAttempt.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MasteryAssignmentAttempt extends Model
+{
+    const STATUS_IN_PROGRESS = 'in_progress';
+    const STATUS_COMPLETED = 'completed';
+    const STATUS_MASTERED = 'mastered';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'question_ids' => 'array',
+        'variant_identifiers' => 'array',
+        'question_results' => 'array',
+        'score' => 'float',
+        'possible_score' => 'float',
+        'completed_at' => 'datetime'
+    ];
+
+    /**
+     * Return the assignment whose question snapshot this attempt records.
+     */
+    public function assignment()
+    {
+        return $this->belongsTo(Assignment::class);
+    }
+}

--- a/app/Score.php
+++ b/app/Score.php
@@ -116,6 +116,40 @@ class Score extends Model
             return;
         }
         $assignment = Assignment::find($assignment_id);
+        if ($assignment->mastery_retake_enabled) {
+            $best_completed_score = MasteryAssignmentAttempt::where('assignment_id', $assignment_id)
+                ->where('user_id', $student_user_id)
+                ->whereIn('status', [
+                    MasteryAssignmentAttempt::STATUS_COMPLETED,
+                    MasteryAssignmentAttempt::STATUS_MASTERED
+                ])
+                ->max('score');
+
+            // Incomplete whole-assignment attempts retain feedback without changing the saved grade.
+            // without changing the assignment or LMS grade.
+            if ($best_completed_score === null) {
+                return;
+            }
+
+            $assignment_score = self::firstOrNew([
+                'user_id' => $student_user_id,
+                'assignment_id' => $assignment_id
+            ]);
+            $assignment_score->score = $best_completed_score;
+            $assignment_score->save();
+
+            if ($passback_grade) {
+                $lti_launch = DB::table('lti_launches')
+                    ->where('assignment_id', $assignment->id)
+                    ->where('user_id', $student_user_id)
+                    ->first();
+                if ($lti_launch) {
+                    $ltiGradePassBack = new LtiGradePassback();
+                    $ltiGradePassBack->initPassBackByUserIdAndAssignmentId($best_completed_score, $lti_launch);
+                }
+            }
+            return;
+        }
         //initialize
         $assignment_score = 0;
         $submission_scores_by_question_id = [];

--- a/app/Services/MasteryAssignmentAttemptService.php
+++ b/app/Services/MasteryAssignmentAttemptService.php
@@ -1,0 +1,534 @@
+<?php
+
+namespace App\Services;
+
+use App\Assignment;
+use App\Exceptions\MasteryRetakeConflictException;
+use App\MasteryAssignmentAttempt;
+use App\Question;
+use App\Traits\Seed;
+use App\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+
+class MasteryAssignmentAttemptService
+{
+    use Seed;
+
+    const MAX_VARIANT_GENERATION_ATTEMPTS = 10;
+
+    private $eligibility;
+
+    /**
+     * Create the attempt coordinator with the shared assignment eligibility validator.
+     */
+    public function __construct(MasteryRetakeEligibility $eligibility)
+    {
+        $this->eligibility = $eligibility;
+    }
+
+    /**
+     * Return whether whole-assignment attempts are enabled for an assignment.
+     */
+    public function enabled(Assignment $assignment): bool
+    {
+        return (bool)$assignment->mastery_retake_enabled;
+    }
+
+    /**
+     * Evaluate the assignment against the canonical whole-assignment eligibility rules.
+     */
+    public function eligibility(Assignment $assignment, bool $require_questions = true): MasteryRetakeEligibilityResult
+    {
+        return $this->eligibility->evaluate($assignment, [], $require_questions);
+    }
+
+    /**
+     * Return the student's most recent persisted attempt, whether active or completed.
+     */
+    public function latestAttempt(Assignment $assignment, User $user): ?MasteryAssignmentAttempt
+    {
+        return MasteryAssignmentAttempt::where('assignment_id', $assignment->id)
+            ->where('user_id', $user->id)
+            ->orderBy('attempt_number', 'desc')
+            ->first();
+    }
+
+    /**
+     * Return the current attempt at assignment launch, creating attempt one when needed.
+     */
+    public function getOrCreateForLaunch(Assignment $assignment, User $user, array $question_ids): MasteryAssignmentAttempt
+    {
+        $question_ids = array_values(array_map('intval', $question_ids));
+        $existing_attempt = $this->latestAttempt($assignment, $user);
+        if ($existing_attempt) {
+            if ($user->fake_student
+                && array_values(array_map('intval', $existing_attempt->question_ids)) !== $question_ids) {
+                return $this->replaceChangedFakeStudentAttempt($assignment, $user, $question_ids);
+            }
+            return $existing_attempt;
+        }
+
+        $eligibility = $this->eligibility($assignment);
+        if (!$eligibility->eligible()) {
+            throw new MasteryRetakeConflictException('ineligible_assignment', $eligibility->firstMessage());
+        }
+
+        try {
+            return DB::transaction(function () use ($assignment, $user, $question_ids) {
+                $latest = MasteryAssignmentAttempt::where('assignment_id', $assignment->id)
+                    ->where('user_id', $user->id)
+                    ->orderBy('attempt_number', 'desc')
+                    ->lockForUpdate()
+                    ->first();
+
+                if ($latest) {
+                    return $latest;
+                }
+
+                return $this->createInitialAttempt($assignment, $user, $question_ids);
+            });
+        } catch (QueryException $e) {
+            // A concurrent initial launch may win the unique attempt-number insert.
+            $attempt = $this->latestAttempt($assignment, $user);
+            if ($attempt) {
+                return $attempt;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Reject callbacks that do not belong to the student's active assignment attempt.
+     */
+    public function validateSubmission(
+        Assignment $assignment,
+        User $user,
+        $attempt_id,
+        ?int $question_id = null
+    ): ?MasteryAssignmentAttempt
+    {
+        if (!$this->enabled($assignment) || $user->role !== 3) {
+            return null;
+        }
+
+        if (!$attempt_id) {
+            $this->logStaleSubmission($assignment, $user, null, 'missing_attempt_id');
+            throw new MasteryRetakeConflictException(
+                'missing_attempt_id',
+                'This submission is missing its assignment attempt identifier. Refresh the assignment and try again.'
+            );
+        }
+
+        $attempt = MasteryAssignmentAttempt::where('id', $attempt_id)
+            ->where('assignment_id', $assignment->id)
+            ->where('user_id', $user->id)
+            ->first();
+
+        if (!$attempt || $attempt->status !== MasteryAssignmentAttempt::STATUS_IN_PROGRESS) {
+            $this->logStaleSubmission($assignment, $user, $attempt_id, 'stale_attempt');
+            throw new MasteryRetakeConflictException(
+                'stale_attempt',
+                'This question belongs to an earlier assignment attempt. Refresh the assignment before submitting.'
+            );
+        }
+
+        if ($question_id !== null && !in_array($question_id, array_map('intval', $attempt->question_ids), true)) {
+            $this->logStaleSubmission($assignment, $user, $attempt_id, 'question_not_in_attempt');
+            throw new MasteryRetakeConflictException(
+                'question_not_in_attempt',
+                'This question does not belong to the active assignment attempt. Refresh the assignment and try again.'
+            );
+        }
+
+        return $attempt;
+    }
+
+    /**
+     * Lock and recheck the active attempt inside the submission transaction.
+     */
+    public function lockForSubmission(Assignment $assignment, User $user, int $attempt_id): MasteryAssignmentAttempt
+    {
+        $attempt = MasteryAssignmentAttempt::where('id', $attempt_id)
+            ->where('assignment_id', $assignment->id)
+            ->where('user_id', $user->id)
+            ->lockForUpdate()
+            ->first();
+
+        if (!$attempt || $attempt->status !== MasteryAssignmentAttempt::STATUS_IN_PROGRESS) {
+            $this->logStaleSubmission($assignment, $user, $attempt_id, 'attempt_closed_during_submission');
+            throw new MasteryRetakeConflictException(
+                'stale_attempt',
+                'This assignment attempt has already closed. Refresh the assignment before submitting.'
+            );
+        }
+
+        return $attempt;
+    }
+
+    /**
+     * Complete an attempt after every snapshotted question has one recorded response.
+     * The caller must hold the submission transaction and attempt row lock.
+     */
+    public function completeIfReady(Assignment $assignment, User $user, MasteryAssignmentAttempt $attempt): array
+    {
+        $question_ids = array_values(array_map('intval', $attempt->question_ids));
+        $submissions = DB::table('submissions')
+            ->where('assignment_id', $assignment->id)
+            ->where('user_id', $user->id)
+            ->whereIn('question_id', $question_ids)
+            ->get()
+            ->keyBy('question_id');
+
+        if ($submissions->count() !== count($question_ids)) {
+            return ['completed' => false, 'attempt' => $attempt];
+        }
+
+        $assignment_questions = DB::table('assignment_question')
+            ->join('questions', 'assignment_question.question_id', '=', 'questions.id')
+            ->where('assignment_question.assignment_id', $assignment->id)
+            ->whereIn('assignment_question.question_id', $question_ids)
+            ->select(
+                'assignment_question.question_id',
+                'assignment_question.points',
+                'questions.technology'
+            )
+            ->get()
+            ->keyBy('question_id');
+        $variants = DB::table('seeds')
+            ->where('assignment_id', $assignment->id)
+            ->where('user_id', $user->id)
+            ->whereIn('question_id', $question_ids)
+            ->pluck('seed', 'question_id')
+            ->toArray();
+
+        $score = 0.0;
+        $possible_score = 0.0;
+        $all_correct = true;
+        $question_results = [];
+
+        foreach ($question_ids as $question_id) {
+            $submission = $submissions->get($question_id);
+            $assignment_question = $assignment_questions->get($question_id);
+            if (!$submission || !$assignment_question) {
+                throw new RuntimeException('The assignment attempt question set changed while the attempt was active.');
+            }
+
+            $question_score = (float)$submission->score;
+            $question_possible_score = (float)$assignment_question->points;
+            $correct = (bool)$submission->answered_correctly_at_least_once;
+            $score += $question_score;
+            $possible_score += $question_possible_score;
+            $all_correct = $all_correct && $correct;
+            $question_results[] = [
+                'question_id' => $question_id,
+                'technology' => $assignment_question->technology,
+                'variant_identifier' => $variants[$question_id] ?? null,
+                'submission' => $submission->submission,
+                'score' => $question_score,
+                'possible_score' => $question_possible_score,
+                'correct' => $correct,
+                'submitted_at' => $submission->updated_at
+            ];
+        }
+
+        if ($possible_score <= 0) {
+            throw new RuntimeException('An assignment attempt must have a positive possible score.');
+        }
+
+        $attempt->status = $all_correct
+            ? MasteryAssignmentAttempt::STATUS_MASTERED
+            : MasteryAssignmentAttempt::STATUS_COMPLETED;
+        $attempt->variant_identifiers = $variants;
+        $attempt->question_results = $question_results;
+        $attempt->score = $score;
+        $attempt->possible_score = $possible_score;
+        $attempt->completed_at = now();
+        $attempt->save();
+
+        Log::info('mastery_attempt.completed', $this->logContext($attempt) + [
+            'score' => $score,
+            'possible_score' => $possible_score,
+            'mastered' => $all_correct
+        ]);
+
+        return ['completed' => true, 'attempt' => $attempt];
+    }
+
+    /**
+     * Replace current response state and start the next whole-assignment attempt.
+     */
+    public function startNextAttempt(Assignment $assignment, User $user, int $previous_attempt_id): array
+    {
+        $eligibility = $this->eligibility($assignment);
+        if (!$eligibility->eligible()) {
+            throw new MasteryRetakeConflictException('ineligible_assignment', $eligibility->firstMessage());
+        }
+
+        return DB::transaction(function () use ($assignment, $user, $previous_attempt_id) {
+            $latest = MasteryAssignmentAttempt::where('assignment_id', $assignment->id)
+                ->where('user_id', $user->id)
+                ->orderBy('attempt_number', 'desc')
+                ->lockForUpdate()
+                ->first();
+
+            if (!$latest) {
+                throw new MasteryRetakeConflictException('no_completed_attempt', 'There is no completed assignment attempt to restart.');
+            }
+
+            if ($latest->status === MasteryAssignmentAttempt::STATUS_IN_PROGRESS) {
+                $previous = MasteryAssignmentAttempt::where('assignment_id', $assignment->id)
+                    ->where('user_id', $user->id)
+                    ->where('attempt_number', $latest->attempt_number - 1)
+                    ->first();
+                if ($previous && $previous->id === $previous_attempt_id) {
+                    return ['attempt' => $latest, 'already_started' => true];
+                }
+                throw new MasteryRetakeConflictException('attempt_in_progress', 'An assignment attempt is already in progress.');
+            }
+
+            if ($latest->id !== $previous_attempt_id) {
+                throw new MasteryRetakeConflictException('stale_retake', 'The requested assignment attempt is no longer current. Refresh the assignment.');
+            }
+
+            if (!$this->canRetake($latest)) {
+                throw new MasteryRetakeConflictException(
+                    'attempt_limit_reached',
+                    'You have used all available assignment attempts.'
+                );
+            }
+
+            $question_ids = array_values(array_map('intval', $latest->question_ids));
+            $old_variants = $latest->variant_identifiers ?: [];
+            $new_variants = [];
+
+            foreach ($question_ids as $question_id) {
+                $question = Question::find($question_id);
+                if (!$question || !in_array($question->technology, ['qti', 'webwork', 'imathas'], true)) {
+                    throw new MasteryRetakeConflictException(
+                        'question_set_changed',
+                        'The assignment question set is no longer eligible for whole-assignment attempts.'
+                    );
+                }
+                $old_variant = $old_variants[$question_id] ?? $old_variants[(string)$question_id] ?? null;
+                $new_variants[$question_id] = $this->nextVariant($assignment, $question, $old_variant);
+            }
+
+            $this->clearActiveAttemptState($assignment, $user);
+            foreach ($new_variants as $question_id => $variant_identifier) {
+                DB::table('seeds')->insert([
+                    'assignment_id' => $assignment->id,
+                    'question_id' => $question_id,
+                    'user_id' => $user->id,
+                    'seed' => $variant_identifier,
+                    'created_at' => now(),
+                    'updated_at' => now()
+                ]);
+            }
+
+            $attempt = MasteryAssignmentAttempt::create([
+                'assignment_id' => $assignment->id,
+                'user_id' => $user->id,
+                'attempt_number' => $latest->attempt_number + 1,
+                'status' => MasteryAssignmentAttempt::STATUS_IN_PROGRESS,
+                'question_ids' => $question_ids,
+                'variant_identifiers' => $new_variants
+            ]);
+
+            Log::info('mastery_attempt.retake_started', $this->logContext($attempt) + [
+                'previous_attempt_id' => $latest->id
+            ]);
+
+            return ['attempt' => $attempt, 'already_started' => false];
+        });
+    }
+
+    /**
+     * Format the attempt state consumed by the student assignment interface.
+     */
+    public function payload(?MasteryAssignmentAttempt $attempt): ?array
+    {
+        if (!$attempt) {
+            return null;
+        }
+        return [
+            'id' => $attempt->id,
+            'number' => $attempt->attempt_number,
+            'status' => $attempt->status,
+            'score' => $attempt->score,
+            'possible_score' => $attempt->possible_score,
+            'can_retake' => $this->canRetake($attempt)
+        ];
+    }
+
+    /**
+     * Return whether a non-preview student has started a whole-assignment attempt.
+     */
+    public function hasRealStudentAttempts(Assignment $assignment): bool
+    {
+        return MasteryAssignmentAttempt::where('assignment_id', $assignment->id)
+            ->join('users', 'mastery_assignment_attempts.user_id', '=', 'users.id')
+            ->where('users.fake_student', 0)
+            ->where('users.formative_student', 0)
+            ->where('users.role', 3)
+            ->exists();
+    }
+
+    /**
+     * Rebuild fake-student preview state after an instructor changes question membership.
+     */
+    private function replaceChangedFakeStudentAttempt(
+        Assignment $assignment,
+        User $user,
+        array $question_ids
+    ): MasteryAssignmentAttempt
+    {
+        $eligibility = $this->eligibility($assignment);
+        if (!$eligibility->eligible()) {
+            throw new MasteryRetakeConflictException('ineligible_assignment', $eligibility->firstMessage());
+        }
+
+        return DB::transaction(function () use ($assignment, $user, $question_ids) {
+            $latest = MasteryAssignmentAttempt::where('assignment_id', $assignment->id)
+                ->where('user_id', $user->id)
+                ->orderBy('attempt_number', 'desc')
+                ->lockForUpdate()
+                ->first();
+            if ($latest && array_values(array_map('intval', $latest->question_ids)) === $question_ids) {
+                return $latest;
+            }
+
+            $this->clearActiveAttemptState($assignment, $user);
+            MasteryAssignmentAttempt::where('assignment_id', $assignment->id)
+                ->where('user_id', $user->id)
+                ->delete();
+            return $this->createInitialAttempt($assignment, $user, $question_ids);
+        });
+    }
+
+    /**
+     * Persist the first in-progress attempt for the supplied question snapshot.
+     */
+    private function createInitialAttempt(
+        Assignment $assignment,
+        User $user,
+        array $question_ids
+    ): MasteryAssignmentAttempt
+    {
+        $attempt = MasteryAssignmentAttempt::create([
+            'assignment_id' => $assignment->id,
+            'user_id' => $user->id,
+            'attempt_number' => 1,
+            'status' => MasteryAssignmentAttempt::STATUS_IN_PROGRESS,
+            'question_ids' => $question_ids
+        ]);
+
+        Log::info('mastery_attempt.created', $this->logContext($attempt));
+        return $attempt;
+    }
+
+    /**
+     * Return whether the completed attempt is below the instructor's attempt limit.
+     */
+    private function canRetake(MasteryAssignmentAttempt $attempt): bool
+    {
+        if (!in_array($attempt->status, [
+            MasteryAssignmentAttempt::STATUS_COMPLETED,
+            MasteryAssignmentAttempt::STATUS_MASTERED
+        ], true)) {
+            return false;
+        }
+
+        $limit = $attempt->assignment->mastery_number_of_allowed_attempts ?: 'unlimited';
+        return $limit === 'unlimited' || $attempt->attempt_number < (int)$limit;
+    }
+
+    /**
+     * Generate a variant identifier different from the preceding attempt.
+     */
+    private function differentVariant(Assignment $assignment, Question $question, $old_variant)
+    {
+        for ($generation_attempt = 1; $generation_attempt <= self::MAX_VARIANT_GENERATION_ATTEMPTS; $generation_attempt++) {
+            $variant = $this->createSeedByTechnologyAssignmentAndQuestion($assignment, $question);
+            if ((string)$variant !== (string)$old_variant) {
+                return $variant;
+            }
+        }
+
+        Log::warning('mastery_attempt.variant_generation_failed', [
+            'assignment_id' => $assignment->id,
+            'question_id' => $question->id,
+            'maximum_attempts' => self::MAX_VARIANT_GENERATION_ATTEMPTS
+        ]);
+        throw new RuntimeException('A different problem version could not be generated. Please try starting the assignment attempt again.');
+    }
+
+    /**
+     * Reuse fixed versions and require a new version only for algorithmic providers.
+     */
+    private function nextVariant(Assignment $assignment, Question $question, $old_variant)
+    {
+        if ($question->technology === 'qti' || !$assignment->algorithmic) {
+            return $this->createSeedByTechnologyAssignmentAndQuestion($assignment, $question);
+        }
+
+        return $this->differentVariant($assignment, $question, $old_variant);
+    }
+
+    /**
+     * Clear only current-attempt records before installing the next set of variants.
+     */
+    private function clearActiveAttemptState(Assignment $assignment, User $user): void
+    {
+        // Starting another attempt clears current responses and feedback; the completed snapshot
+        // remains authoritative. Ownership of the current-state tables follows these existing paths:
+        // - submissions, seeds, can_give_ups, shown_hints, and submission_histories
+        //   mirror SubmissionController::resetSubmission().
+        // - unconfirmed_submissions is written by JWTController before confirmed WeBWorK grading.
+        // - submission_confirmations is written by SubmissionConfirmationController.
+        $tables = [
+            'submissions',
+            'seeds',
+            'can_give_ups',
+            'shown_hints',
+            'submission_histories',
+            'unconfirmed_submissions',
+            'submission_confirmations'
+        ];
+        foreach ($tables as $table) {
+            DB::table($table)
+                ->where('assignment_id', $assignment->id)
+                ->where('user_id', $user->id)
+                ->delete();
+        }
+    }
+
+    /**
+     * Record enough context to diagnose a rejected late or duplicate callback.
+     */
+    private function logStaleSubmission(Assignment $assignment, User $user, $attempt_id, string $reason): void
+    {
+        Log::warning('mastery_attempt.stale_submission', [
+            'assignment_id' => $assignment->id,
+            'user_id' => $user->id,
+            'attempt_id' => $attempt_id,
+            'reason' => $reason
+        ]);
+    }
+
+    /**
+     * Build the common structured-log context for an attempt lifecycle event.
+     */
+    private function logContext(MasteryAssignmentAttempt $attempt): array
+    {
+        return [
+            'assignment_id' => $attempt->assignment_id,
+            'user_id' => $attempt->user_id,
+            'attempt_id' => $attempt->id,
+            'attempt_number' => $attempt->attempt_number,
+            'status' => $attempt->status
+        ];
+    }
+}

--- a/app/Services/MasteryRetakeEligibility.php
+++ b/app/Services/MasteryRetakeEligibility.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Services;
+
+use App\Assignment;
+use Illuminate\Support\Facades\DB;
+
+class MasteryRetakeEligibility
+{
+    /**
+     * Return stable eligibility reasons for assignment properties and assigned questions.
+     */
+    public function evaluate(Assignment $assignment, array $overrides = [], bool $require_questions = true): MasteryRetakeEligibilityResult
+    {
+        $reasons = [];
+        $value = function (string $property) use ($assignment, $overrides) {
+            return array_key_exists($property, $overrides)
+                ? $overrides[$property]
+                : $assignment->{$property};
+        };
+
+        $this->require($reasons,
+            $value('assessment_type') === 'real time',
+            'assessment_type',
+            'Whole-assignment attempts require a real-time assignment.');
+        $this->require($reasons,
+            $value('scoring_type') === 'p',
+            'scoring_type',
+            'Whole-assignment attempts require point-based scoring.');
+        $this->require($reasons,
+            (string)$value('number_of_allowed_attempts') === '1',
+            'question_attempts',
+            'Whole-assignment attempts require one response per question.');
+        $this->require($reasons,
+            (int)$value('randomizations') === 0,
+            'random_sampling',
+            'Whole-assignment attempts do not currently support ADAPT question sampling.');
+        $this->require($reasons,
+            empty($value('number_of_randomized_assessments')),
+            'random_sampling',
+            'Whole-assignment attempts do not currently support ADAPT question sampling.');
+        $this->require($reasons,
+            !(bool)$value('can_submit_work'),
+            'submitted_work',
+            'Whole-assignment attempts do not support required submitted work.');
+        $this->require($reasons,
+            $this->percentIsZero($value('hint_penalty')),
+            'hint_penalty',
+            'Whole-assignment attempts require a zero hint penalty.');
+        $this->require($reasons,
+            $this->percentIsZero($value('number_of_allowed_attempts_penalty')),
+            'attempt_penalty',
+            'Whole-assignment attempts require a zero attempt penalty.');
+        $this->require($reasons,
+            $value('late_policy') !== 'deduction',
+            'late_deduction',
+            'Whole-assignment attempts do not support late score deductions.');
+
+        if (!$assignment->exists) {
+            return new MasteryRetakeEligibilityResult($reasons);
+        }
+
+        $this->require($reasons,
+            !(bool)$assignment->course->anonymous_users,
+            'anonymous_users',
+            'Whole-assignment attempts are not available in courses that allow anonymous users.');
+
+        $questions = DB::table('assignment_question')
+            ->join('questions', 'assignment_question.question_id', '=', 'questions.id')
+            ->where('assignment_question.assignment_id', $assignment->id)
+            ->select(
+                'questions.id',
+                'questions.technology',
+                'assignment_question.open_ended_submission_type',
+                'assignment_question.points'
+            )
+            ->get();
+
+        if ($require_questions) {
+            $this->require($reasons,
+                $questions->isNotEmpty(),
+                'no_questions',
+                'Whole-assignment attempts require at least one assigned question.');
+        }
+
+        foreach ($questions as $question) {
+            if (!in_array($question->technology, ['qti', 'webwork', 'imathas'], true)) {
+                $this->addReason($reasons,
+                    'unsupported_question',
+                    "Question {$question->id} is not a supported auto-graded question.");
+            }
+            if ((string)$question->open_ended_submission_type !== '0') {
+                $this->addReason($reasons,
+                    'open_ended_question',
+                    "Question {$question->id} includes an open-ended response.");
+            }
+            if (!is_numeric($question->points) || (float)$question->points <= 0) {
+                $this->addReason($reasons,
+                    'invalid_question_points',
+                    "Question {$question->id} must have more than zero points.");
+            }
+        }
+
+        return new MasteryRetakeEligibilityResult($reasons);
+    }
+
+    /**
+     * Add an eligibility reason when a required condition is not met.
+     */
+    private function require(array &$reasons, bool $condition, string $code, string $message): void
+    {
+        if (!$condition) {
+            $this->addReason($reasons, $code, $message);
+        }
+    }
+
+    /**
+     * Add a unique machine-readable reason and its instructor-facing message.
+     */
+    private function addReason(array &$reasons, string $code, string $message): void
+    {
+        foreach ($reasons as $reason) {
+            if ($reason['code'] === $code && $reason['message'] === $message) {
+                return;
+            }
+        }
+        $reasons[] = compact('code', 'message');
+    }
+
+    /**
+     * Treat empty percentage fields and numeric zero as a zero penalty.
+     */
+    private function percentIsZero($value): bool
+    {
+        if ($value === null || $value === '') {
+            return true;
+        }
+        return (float)str_replace('%', '', (string)$value) === 0.0;
+    }
+}

--- a/app/Services/MasteryRetakeEligibilityResult.php
+++ b/app/Services/MasteryRetakeEligibilityResult.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Services;
+
+class MasteryRetakeEligibilityResult
+{
+    private $reasons;
+
+    /**
+     * Store eligibility failures in their deterministic evaluation order.
+     */
+    public function __construct(array $reasons = [])
+    {
+        $this->reasons = array_values($reasons);
+    }
+
+    /**
+     * Return whether no eligibility failures were found.
+     */
+    public function eligible(): bool
+    {
+        return count($this->reasons) === 0;
+    }
+
+    /**
+     * Return all machine-readable eligibility failures.
+     */
+    public function reasons(): array
+    {
+        return $this->reasons;
+    }
+
+    /**
+     * Return the first instructor-facing failure message, if any.
+     */
+    public function firstMessage(): string
+    {
+        return $this->eligible()
+            ? ''
+            : $this->reasons[0]['message'];
+    }
+
+}

--- a/app/Submission.php
+++ b/app/Submission.php
@@ -4,7 +4,9 @@
 namespace App;
 
 use App\Exceptions\Handler;
+use App\Exceptions\MasteryRetakeConflictException;
 use App\Helpers\Helper;
+use App\Services\MasteryAssignmentAttemptService;
 use App\Traits\JWT;
 use DOMDocument;
 use \Exception;
@@ -934,6 +936,24 @@ class Submission extends Model
         $data['user_id'] = Auth::user()->id;
         $assignment = $Assignment->find($data['assignment_id']);
 
+        $mastery_attempt_service = app(MasteryAssignmentAttemptService::class);
+        $mastery_attempt = null;
+        try {
+            $mastery_attempt = $mastery_attempt_service->validateSubmission(
+                $assignment,
+                Auth::user(),
+                $data['mastery_attempt_id'] ?? null,
+                (int)$data['question_id']
+            );
+        } catch (MasteryRetakeConflictException $e) {
+            return [
+                'type' => 'error',
+                'status' => 409,
+                'reason' => $e->reason(),
+                'message' => $e->getMessage()
+            ];
+        }
+
 
         if ($assignment->course->anonymous_users && (Helper::isAnonymousUser() || Helper::hasAnonymousUserSession())) {
             $response['type'] = 'success';
@@ -1063,6 +1083,7 @@ class Submission extends Model
 
         $data['all_correct'] = $data['score'] >= floatval($assignment_question->points);//>= so I don't worry about decimals
 
+        $mastery_completion = ['completed' => false, 'attempt' => $mastery_attempt];
         try {
             //do the extension stuff also
             $submission = Submission::where('user_id', $data['user_id'])
@@ -1124,6 +1145,10 @@ class Submission extends Model
                         $plural = $assignment->number_of_allowed_attempts === '1' ? '' : 's';
                         $message = "You are only allowed $assignment->number_of_allowed_attempts attempt$plural.  ";
                         $response['message'] = $message;
+                        if ($mastery_attempt) {
+                            $response['status'] = 409;
+                            $response['reason'] = 'duplicate_submission';
+                        }
                         if ($assignment->assessment_type === 'learning tree') {
                             $response['learning_tree_message'] = true;
                             $response['message'] = $message;
@@ -1163,6 +1188,13 @@ class Submission extends Model
                     }
                 }
                 DB::beginTransaction();
+                if ($mastery_attempt) {
+                    $mastery_attempt = $mastery_attempt_service->lockForSubmission(
+                        $assignment,
+                        Auth::user(),
+                        $mastery_attempt->id
+                    );
+                }
                 $submission->submission = $data['submission'];
                 $submission->answered_correctly_at_least_once = $data['all_correct'];
                 $submission->score = request()->user()->role === 3 ? $this->applyLatePenalyToScore($assignment, $data['score']) : $data['score'];
@@ -1201,6 +1233,22 @@ class Submission extends Model
                     }
                 }
                 DB::beginTransaction();
+                if ($mastery_attempt) {
+                    $mastery_attempt = $mastery_attempt_service->lockForSubmission(
+                        $assignment,
+                        Auth::user(),
+                        $mastery_attempt->id
+                    );
+                    if (Submission::where('user_id', $data['user_id'])
+                        ->where('assignment_id', $data['assignment_id'])
+                        ->where('question_id', $data['question_id'])
+                        ->exists()) {
+                        throw new MasteryRetakeConflictException(
+                            'duplicate_submission',
+                            'A response to this question has already been recorded for the active attempt.'
+                        );
+                    }
+                }
                 $submission = Submission::create(['user_id' => $data['user_id'],
                     'assignment_id' => $data['assignment_id'],
                     'question_id' => $data['question_id'],
@@ -1251,10 +1299,22 @@ class Submission extends Model
                 }
             }
 
-            $score->updateAssignmentScore($data['user_id'], $assignment->id, $assignment->lms_grade_passback === 'automatic');
+            if ($mastery_attempt) {
+                $mastery_completion = $mastery_attempt_service->completeIfReady(
+                    $assignment,
+                    Auth::user(),
+                    $mastery_attempt
+                );
+                if ($mastery_completion['completed']) {
+                    $score->updateAssignmentScore($data['user_id'], $assignment->id, false);
+                }
+                $response['mastery_attempt'] = $mastery_attempt_service->payload($mastery_completion['attempt']);
+            } else {
+                $score->updateAssignmentScore($data['user_id'], $assignment->id, $assignment->lms_grade_passback === 'automatic');
+            }
             try {
                 $assignment_course_info = $assignment->assignmentCourseInfo();
-                if ($assignment_course_info->instructor === 'Brian Lindshield') {
+                if (!$mastery_attempt && $assignment_course_info->instructor === 'Brian Lindshield') {
                     $assignment_score = Score::where('user_id', request()->user()->id)
                         ->where('assignment_id', $data['assignment_id'])
                         ->first();
@@ -1307,6 +1367,27 @@ class Submission extends Model
             }
 
             DB::commit();
+            if ($mastery_completion['completed'] && $assignment->lms_grade_passback === 'automatic') {
+                try {
+                    // Mastery completion is locally authoritative. Passback happens only
+                    // after the attempt and best score have committed successfully.
+                    $score->updateAssignmentScore($data['user_id'], $assignment->id, true);
+                } catch (Exception $passback_exception) {
+                    Log::error('mastery_attempt.passback_failed', [
+                        'assignment_id' => $assignment->id,
+                        'user_id' => $data['user_id'],
+                        'attempt_id' => $mastery_completion['attempt']->id,
+                        'message' => $passback_exception->getMessage()
+                    ]);
+                    $h = new Handler(app());
+                    $h->report($passback_exception);
+                }
+            }
+        } catch (MasteryRetakeConflictException $e) {
+            DB::rollback();
+            $response['status'] = 409;
+            $response['reason'] = $e->reason();
+            $response['message'] = $e->getMessage();
         } catch (Exception $e) {
             DB::rollback();
             $h = new Handler(app());

--- a/app/Traits/AssignmentProperties.php
+++ b/app/Traits/AssignmentProperties.php
@@ -193,6 +193,8 @@ trait AssignmentProperties
             'submitted_work_format' =>+$request->can_submit_work ? json_encode($request->submitted_work_format) : null,
             'hint_penalty' => $this->getHintPenalty($request),
             'algorithmic' => $this->getAlgorithmic($request),
+            'mastery_retake_enabled' => (int)$request->mastery_retake_enabled,
+            'mastery_number_of_allowed_attempts' => $request->mastery_number_of_allowed_attempts,
             'solutions_availability' => $this->getSolutionsAvailability($request),
             'flashcard_settings' => $request->assessment_type === 'flashcard' ? json_encode($request->flashcard_settings) : null,
             // learning tree
@@ -233,6 +235,8 @@ trait AssignmentProperties
     public function getDataToUpdate($data, $request)
     {
         $data['number_of_allowed_attempts'] = $this->getNumberOfAllowedAttempts($request);
+        $data['mastery_retake_enabled'] = (int)$request->mastery_retake_enabled;
+        $data['mastery_number_of_allowed_attempts'] = $request->mastery_number_of_allowed_attempts;
         $data['number_of_allowed_attempts_penalty'] = $this->getNumberOfAllowedAttemptsPenalty($request);
         $data['can_view_hint'] = $request->can_view_hint;
         $data['hint_penalty'] = $this->getHintPenalty($request);

--- a/database/migrations/2026_07_14_000001_add_mastery_retake_enabled_to_assignments.php
+++ b/database/migrations/2026_07_14_000001_add_mastery_retake_enabled_to_assignments.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddMasteryRetakeEnabledToAssignments extends Migration
+{
+    /**
+     * Add the opt-in mastery mode and its assignment-attempt limit.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('assignments', function (Blueprint $table) {
+            $table->boolean('mastery_retake_enabled')
+                ->default(false)
+                ->after('algorithmic');
+            $table->string('mastery_number_of_allowed_attempts', 10)
+                ->default('unlimited')
+                ->after('mastery_retake_enabled');
+        });
+
+        Schema::table('assignment_templates', function (Blueprint $table) {
+            $table->boolean('mastery_retake_enabled')
+                ->default(false)
+                ->after('algorithmic');
+            $table->string('mastery_number_of_allowed_attempts', 10)
+                ->default('unlimited')
+                ->after('mastery_retake_enabled');
+        });
+    }
+
+    /**
+     * Remove the mastery assignment properties.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('assignment_templates', function (Blueprint $table) {
+            $table->dropColumn(['mastery_retake_enabled', 'mastery_number_of_allowed_attempts']);
+        });
+
+        Schema::table('assignments', function (Blueprint $table) {
+            $table->dropColumn(['mastery_retake_enabled', 'mastery_number_of_allowed_attempts']);
+        });
+    }
+}

--- a/database/migrations/2026_07_14_000002_create_mastery_assignment_attempts_table.php
+++ b/database/migrations/2026_07_14_000002_create_mastery_assignment_attempts_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMasteryAssignmentAttemptsTable extends Migration
+{
+    /**
+     * Create the persistent snapshot and lifecycle record for each assignment attempt.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('mastery_assignment_attempts', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('assignment_id');
+            $table->unsignedBigInteger('user_id');
+            $table->unsignedInteger('attempt_number');
+            $table->string('status', 16)->default('in_progress');
+            $table->json('question_ids');
+            $table->json('variant_identifiers')->nullable();
+            $table->json('question_results')->nullable();
+            $table->decimal('score', 12, 4)->nullable();
+            $table->decimal('possible_score', 12, 4)->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['assignment_id', 'user_id', 'attempt_number'], 'mastery_attempt_number_unique');
+            $table->index(['assignment_id', 'user_id', 'status'], 'mastery_attempt_status_index');
+            $table->foreign('assignment_id')->references('id')->on('assignments');
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Remove whole-assignment attempt history.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('mastery_assignment_attempts');
+    }
+}

--- a/resources/js/components/AssignmentProperties.vue
+++ b/resources/js/components/AssignmentProperties.vue
@@ -409,11 +409,11 @@
                 </b-col>
 
                 <b-modal id="modal-number-of-allowed-attempts-penalty-warning"
-                         title="Number of Allowed Attempts Penalty"
+                         title="Penalty per Additional Response"
                 >
                   <p>
-                    You are about to update the number of allowed attempts penalty but there are already submissions in
-                    this assignment. Please note that this new penalty will only apply to future submissions.
+                    You are about to update the penalty per additional response, but this assignment already has
+                    submissions. The new penalty will apply only to future responses.
                   </p>
                   <template #modal-footer="{ cancel, ok }">
                     <b-button size="sm" variant="primary"
@@ -1032,23 +1032,66 @@
               </b-form-group>
             </div>
 
-            <!-- Number of Allowed Attempts: hidden for flashcard (forced unlimited) -->
+            <b-form-group
+              v-if="form.assessment_type === 'real time' && form.scoring_type === 'p'"
+              label-cols-sm="4"
+              label-cols-lg="3"
+              label-for="mastery_retake_enabled"
+            >
+              <template v-slot:label>
+                Assignment Attempt Policy*
+                <QuestionCircleTooltip :id="'attempt-structure-tooltip'"/>
+                <b-tooltip target="attempt-structure-tooltip" delay="250" triggers="hover focus">
+                  Choose whether students attempt each question independently or complete every question as part of
+                  one assignment attempt.
+                </b-tooltip>
+              </template>
+              <b-form-radio-group
+                id="mastery_retake_enabled"
+                v-model="form.mastery_retake_enabled"
+                stacked
+                required
+                :disabled="isLocked(hasSubmissionsOrFileSubmissions) || isBetaAssignment"
+                @change="initMasteryRetakes"
+              >
+                <b-form-radio :value="0">
+                  Per-question attempts
+                  <QuestionCircleTooltip :id="'per-question-attempts-tooltip'"/>
+                  <b-tooltip target="per-question-attempts-tooltip" delay="250" triggers="hover focus">
+                    Each question has its own response limit and immediate feedback. Students continue working on
+                    incorrect questions using the same problem version. Correct questions remain complete.
+                  </b-tooltip>
+                </b-form-radio>
+                <b-form-radio :value="1">
+                  Whole-assignment attempts
+                  <QuestionCircleTooltip :id="'whole-assignment-attempts-tooltip'"/>
+                  <b-tooltip target="whole-assignment-attempts-tooltip" delay="250" triggers="hover focus">
+                    Students submit one response to every question during each assignment attempt. Starting a new
+                    attempt clears the current responses, includes every question again, and generates new algorithmic
+                    problem versions when question variation is enabled.
+                  </b-tooltip>
+                </b-form-radio>
+              </b-form-radio-group>
+              <has-error :form="form" field="mastery_retake_enabled"/>
+            </b-form-group>
+
             <div v-if="form.assessment_type !== 'flashcard' && (form.assessment_type === 'clicker' ||
           (['real time','learning tree'].includes(form.assessment_type) && form.scoring_type === 'p'))"
             >
               <b-form-group
+                v-if="!Boolean(form.mastery_retake_enabled)"
                 label-cols-sm="4"
                 label-cols-lg="3"
                 label-for="number_of_allowed_attempts"
               >
                 <template v-slot:label>
-                  Number of Allowed Attempts*
+                  Responses per Question*
                   <QuestionCircleTooltip :id="'number-of-allowed-attempts-tooltip'"/>
                   <b-tooltip target="number-of-allowed-attempts-tooltip"
                              delay="250"
                              triggers="hover focus"
                   >
-                    <span v-if="form.assessment_type === 'real time'">Optionally, you can let your students attempt real time assessments multiple times.</span>
+                    <span v-if="form.assessment_type === 'real time'">Choose how many responses a student may submit to each question.</span>
                     <span v-if="form.assessment_type === 'learning tree'">Students will always be allowed to re-attempt Learning Tree assessments.  However, you can dictate the number of attempts possible.</span>
                     Please note that if you have any H5P questions in your assignment, then due to
                     the nature of H5P, your students will see the answer
@@ -1069,7 +1112,7 @@
                         type="text"
                         :style="form.number_of_allowed_attempts === 'unlimited' ? 'pointer-events: none;' : ''"
                         :disabled="isBetaAssignment || form.number_of_allowed_attempts === 'unlimited'"
-                        aria-label="Number of allowed attempts"
+                        aria-label="Responses allowed per question"
                         placeholder="1, 2, 3, ..."
                         @input="val => {
           form.number_of_allowed_attempts = val;
@@ -1093,20 +1136,72 @@
                 </div>
               </b-form-group>
               <b-form-group
-                v-if="form.number_of_allowed_attempts !== '1' && form.assessment_type !== 'clicker'"
+                v-if="Boolean(form.mastery_retake_enabled)"
+                label-cols-sm="4"
+                label-cols-lg="3"
+                label-for="mastery_number_of_allowed_attempts"
+              >
+                <template v-slot:label>
+                  Assignment Attempts*
+                  <QuestionCircleTooltip :id="'mastery-number-of-allowed-attempts-tooltip'"/>
+                  <b-tooltip target="mastery-number-of-allowed-attempts-tooltip"
+                             delay="250"
+                             triggers="hover focus"
+                  >
+                    Choose the total number of whole-assignment attempts, including the first attempt. Students may
+                    continue after earning 100% while another attempt is available.
+                  </b-tooltip>
+                </template>
+                <div class="mt-2">
+                  <div class="d-flex align-items-center mb-2">
+                    <div style="width: 100px; cursor: pointer;" @click="() => {
+      if (form.mastery_number_of_allowed_attempts === 'unlimited') {
+        form.mastery_number_of_allowed_attempts = '';
+      }
+    }"
+                    >
+                      <b-form-input
+                        :value="form.mastery_number_of_allowed_attempts !== 'unlimited' ? form.mastery_number_of_allowed_attempts : ''"
+                        type="text"
+                        :style="form.mastery_number_of_allowed_attempts === 'unlimited' ? 'pointer-events: none;' : ''"
+                        :disabled="isBetaAssignment || form.mastery_number_of_allowed_attempts === 'unlimited'"
+                        aria-label="Whole-assignment attempts allowed"
+                        placeholder="1, 2, 3, ..."
+                        @input="val => {
+          form.mastery_number_of_allowed_attempts = val;
+          form.errors.clear('mastery_number_of_allowed_attempts');
+        }"
+                      />
+                    </div>
+                    <span class="mx-3 text-muted">— or —</span>
+                    <b-form-checkbox
+                      :checked="form.mastery_number_of_allowed_attempts === 'unlimited'"
+                      :disabled="isBetaAssignment"
+                      @change="checked => {
+        form.mastery_number_of_allowed_attempts = checked ? 'unlimited' : '';
+        form.errors.clear('mastery_number_of_allowed_attempts');
+      }"
+                    >
+                      Unlimited
+                    </b-form-checkbox>
+                  </div>
+                  <ErrorMessage :message="form.errors.get('mastery_number_of_allowed_attempts')"/>
+                </div>
+              </b-form-group>
+              <b-form-group
+                v-if="!Boolean(form.mastery_retake_enabled) && form.number_of_allowed_attempts !== '1' && form.assessment_type !== 'clicker'"
                 label-cols-sm="4"
                 label-cols-lg="3"
                 label-for="attempts_penalty"
               >
                 <template v-slot:label>
-                  Attempts Penalty*
+                  Penalty per Additional Response*
                   <QuestionCircleTooltip :id="'attempts-penalty-tooltip'"/>
                   <b-tooltip target="attempts-penalty-tooltip"
                              delay="250"
                              triggers="hover focus"
                   >
-                    If you allow your students to attempt a question multiple times, you may provide a penalty to be
-                    applied for each attempt after the first.
+                    This percentage is deducted for each response to the same question after the first response.
                   </b-tooltip>
                 </template>
                 <b-form-row>
@@ -1474,7 +1569,7 @@
                               v-model="form.randomizations"
                               required
                               stacked
-                              :disabled="isLocked(hasSubmissionsOrFileSubmissions) || isBetaAssignment"
+                              :disabled="isLocked(hasSubmissionsOrFileSubmissions) || isBetaAssignment || Boolean(form.mastery_retake_enabled)"
                               @change="initRandomizationsSwitch($event)"
           >
             <b-form-radio value="1">Yes</b-form-radio>
@@ -1501,7 +1596,7 @@
                 v-model="form.number_of_randomized_assessments"
                 type="text"
                 required
-                :disabled="isLocked(hasSubmissionsOrFileSubmissions) || isBetaAssignment"
+                :disabled="isLocked(hasSubmissionsOrFileSubmissions) || isBetaAssignment || Boolean(form.mastery_retake_enabled)"
                 :class="{ 'is-invalid': form.errors.has('number_of_randomized_assessments') }"
                 @keydown="form.errors.clear('number_of_randomized_assessments')"
               />
@@ -1512,11 +1607,10 @@
         <div v-if="user.role ===2">
           <b-form-group label-cols-sm="4" label-cols-lg="3" label-for="algorithmic">
             <template v-slot:label>
-              Algorithmic*
-              <QuestionCircleTooltip :id="'algorithmic-tooltip'"/>
-              <b-tooltip target="algorithmic-tooltip" delay="250" triggers="hover focus">
-                WeBWork and IMathAS support algorithmic questions. Students will receive slight variations of the
-                original question.
+              Algorithmic Question Variation*
+              <QuestionCircleTooltip :id="'question-versions-tooltip'"/>
+              <b-tooltip target="question-versions-tooltip" delay="250" triggers="hover focus">
+                WeBWorK and IMathAS use a seed to generate question values.
               </b-tooltip>
             </template>
             <b-form-radio-group id="algorithmic"
@@ -1525,8 +1619,8 @@
                                 stacked
                                 :disabled="isLocked(hasSubmissionsOrFileSubmissions)"
             >
-              <b-form-radio value="1">Yes</b-form-radio>
-              <b-form-radio value="0">No</b-form-radio>
+              <b-form-radio value="0">Same version for every student (fixed seed)</b-form-radio>
+              <b-form-radio value="1">Different version for each student (random seed)</b-form-radio>
             </b-form-radio-group>
           </b-form-group>
         </div>
@@ -2234,6 +2328,21 @@ export default {
   },
   methods: {
     isLocked,
+    // Apply the existing property combination required by whole-assignment attempts.
+    initMasteryRetakes (enabled) {
+      this.form.errors.clear('mastery_retake_enabled')
+      if (!enabled) {
+        this.form.mastery_number_of_allowed_attempts = 'unlimited'
+        return
+      }
+      this.form.number_of_allowed_attempts = '1'
+      this.form.number_of_allowed_attempts_penalty = '0%'
+      this.form.randomizations = 0
+      this.form.number_of_randomized_assessments = null
+      this.form.can_submit_work = 0
+      this.form.hint_penalty = '0%'
+      if (this.form.late_policy === 'deduction') this.form.late_policy = 'not accepted'
+    },
     getHeaderHtml (title) {
       return `<h2 class="h7 m-0">${title}</h2>`
     },

--- a/resources/js/helpers/AssignmentProperties.js
+++ b/resources/js/helpers/AssignmentProperties.js
@@ -18,6 +18,8 @@ export const assignmentForm = new Form({
   assign_tos: [],
   formative: 0,
   assessment_type: 'real time',
+  mastery_retake_enabled: 0,
+  mastery_number_of_allowed_attempts: 'unlimited',
   assignment_group_id: null,
   default_open_ended_submission_type: 0,
   can_submit_work: 0,
@@ -179,6 +181,8 @@ export async function initAddAssignment (form, courseId, assignmentGroups, noty,
   form.default_clicker_time_to_submit = ''
   form.instructions = ''
   form.assessment_type = 'real time'
+  form.mastery_retake_enabled = 0
+  form.mastery_number_of_allowed_attempts = 'unlimited'
   form.number_of_allowed_attempts = '1'
   form.number_of_allowed_attempts_penalty = ''
   form.can_view_hint = 1
@@ -268,6 +272,8 @@ export async function editAssignmentProperties (assignmentProperties, vm) {
     }
   }
   vm.form.algorithmic = assignmentProperties.algorithmic
+  vm.form.mastery_retake_enabled = Number(assignmentProperties.mastery_retake_enabled || 0)
+  vm.form.mastery_number_of_allowed_attempts = assignmentProperties.mastery_number_of_allowed_attempts || 'unlimited'
   vm.form.default_clicker_time_to_submit = assignmentProperties.default_clicker_time_to_submit
   vm.form.solutions_availability = assignmentProperties.solutions_availability
   vm.form.public_description = assignmentProperties.public_description

--- a/resources/js/helpers/HandleTechnologyResponse.js
+++ b/resources/js/helpers/HandleTechnologyResponse.js
@@ -278,6 +278,7 @@ export async function processReceiveMessage (vm, routeName, event) {
         'question_id': question.id,
         'submission': event.data,
         'assignment_id': vm.assignmentId,
+        'mastery_attempt_id': vm.masteryAttempt ? vm.masteryAttempt.id : null,
         'technology': technology,
         'max_score': vm.maxScore,
         'is_h5p_activity_set': vm.ish5pActivitySet

--- a/resources/js/pages/instructors/assignment_information/summary.vue
+++ b/resources/js/pages/instructors/assignment_information/summary.vue
@@ -163,13 +163,21 @@ export default {
           { property: 'Assessment Type', value: _.startCase(this.assignment.assessment_type) }
         )
         if (this.assignment.assessment_type === 'real time') {
-          this.items.push(
-            { property: 'Number of Allowed Attempts', value: _.startCase(this.assignment.number_of_allowed_attempts) }
-          )
-          if (this.assignment.number_of_allowed_attempts !== '1') {
+          const wholeAssignmentAttempts = Boolean(this.assignment.mastery_retake_enabled)
+          this.items.push({
+            property: 'Assignment Attempt Policy',
+            value: wholeAssignmentAttempts ? 'Whole-assignment attempts' : 'Per-question attempts'
+          })
+          this.items.push({
+            property: wholeAssignmentAttempts ? 'Assignment Attempts' : 'Responses per Question',
+            value: _.startCase(wholeAssignmentAttempts
+              ? this.assignment.mastery_number_of_allowed_attempts
+              : this.assignment.number_of_allowed_attempts)
+          })
+          if (!wholeAssignmentAttempts && this.assignment.number_of_allowed_attempts !== '1') {
             this.items.push(
               {
-                property: 'Attempts Penalty',
+                property: 'Penalty per Additional Response',
                 value: this.assignment.number_of_allowed_attempts_penalty + '%'
               }
             )

--- a/resources/js/pages/questions.view.vue
+++ b/resources/js/pages/questions.view.vue
@@ -1825,6 +1825,9 @@
                   />
                   {{ getTitle(currentPage) }}
                 </h1>
+                <b-badge v-if="masteryRetakeEnabled && masteryAttempt" variant="info" class="mr-2">
+                  Assignment attempt {{ masteryAttempt.number }} · {{ capitalize(masteryAttempt.status.replace('_', ' ')) }}
+                </b-badge>
                 <small v-show="questionStatus"
                        :class="getQuestionStatusClass()"
                        style="position: relative; top: -2px;"
@@ -1867,6 +1870,38 @@
                 </small>
               </b-col>
             </b-row>
+            <b-alert
+              v-if="masteryRetakeEnabled && masteryAttempt && masteryAttempt.status !== 'in_progress'"
+              :variant="masteryAttempt.status === 'mastered' ? 'success' : 'info'"
+              show
+              class="mt-2 mb-1"
+            >
+              <div class="d-flex flex-wrap align-items-center justify-content-between">
+                <div>
+                  <strong>{{ masteryAttemptResult }}</strong>
+                  <div v-if="masteryCanRetake">
+                    Practice every question again. Your highest score stays the same.
+                  </div>
+                  <div v-else>
+                    No additional assignment attempts are available.
+                  </div>
+                </div>
+                <b-button
+                  v-if="masteryCanRetake"
+                  variant="primary"
+                  class="ml-sm-3 mt-2 mt-sm-0"
+                  :disabled="startingMasteryRetake"
+                  @click="startMasteryRetake"
+                >
+                  <template v-if="startingMasteryRetake">
+                    Preparing Attempt {{ masteryAttempt.number * 1 + 1 }}...
+                  </template>
+                  <template v-else>
+                    Start Attempt {{ masteryAttempt.number * 1 + 1 }}
+                  </template>
+                </b-button>
+              </div>
+            </b-alert>
           </b-container>
         </div>
       </div>
@@ -2768,7 +2803,7 @@
                         @resetResponse="resetSubmission"
                       />
                       <b-alert :show="!submitButtonActive" variant="info">
-                        No additional submissions will be accepted.
+                        {{ closedSubmissionMessage }}
                       </b-alert>
                     </div>
                     <div style="margin-left: auto">
@@ -3157,7 +3192,7 @@
                               @cardChanged="cardChanged"
                             />
                             <b-alert :show="!submitButtonActive && assessmentType !== 'clicker'" variant="info">
-                              No additional submissions will be accepted.
+                              {{ closedSubmissionMessage }}
                             </b-alert>
                           </div>
                           <div
@@ -3197,7 +3232,7 @@
                               />
                             </div>
                             <b-alert :show="!submitButtonActive && iframeDomLoaded" variant="info">
-                              No additional submissions will be accepted.
+                              {{ closedSubmissionMessage }}
                             </b-alert>
                           </div>
                         </div>
@@ -3214,7 +3249,7 @@
                         </b-button>
                       </div>
                       <b-alert :show="!submitButtonActive" variant="info" class="mt-3">
-                        No additional submissions will be accepted.
+                        {{ closedSubmissionMessage }}
                       </b-alert>
                     </div>
                     <div v-if="isOpenEndedTextSubmission && user.role === 3 && !isAnonymousUser">
@@ -3611,7 +3646,7 @@
                     :question-id="+questions[currentPage-1].id"
                   />
                   <b-alert :show="!submitButtonActive" variant="info">
-                    No additional submissions will be accepted.
+                    {{ closedSubmissionMessage }}
                   </b-alert>
                 </div>
               </div>
@@ -3892,6 +3927,9 @@ export default {
     modalSubmissionAcceptedTitle: 'Submission Accepted',
     reportCacheKey: 0,
     completedAllAssignmentQuestions: false,
+    masteryRetakeEnabled: false,
+    masteryAttempt: null,
+    startingMasteryRetake: false,
     submissionArray: [],
     unconfirmedSubmission: [],
     questionNumbersShownOutOfIframe: true,
@@ -4206,6 +4244,36 @@ export default {
     ...mapGetters({
       user: 'auth/user'
     }),
+    // Derive the completion message and action from the server-provided lifecycle state.
+    masteryCanRetake () {
+      return Boolean(this.masteryRetakeEnabled && this.masteryAttempt && this.masteryAttempt.can_retake)
+    },
+    closedSubmissionMessage () {
+      if (!this.masteryRetakeEnabled || !this.masteryAttempt) {
+        const question = this.questions[this.currentPage - 1]
+        if (question && Boolean(Number(question.answered_correctly_at_least_once))) {
+          return 'This question has been answered correctly.'
+        }
+        if (question && this.numberOfAllowedAttempts !== 'unlimited' &&
+          Number(question.submission_count) >= Number(this.numberOfAllowedAttempts)) {
+          return 'This question has reached its response limit.'
+        }
+        return 'No additional submissions will be accepted.'
+      }
+      if (this.masteryAttempt.status === 'in_progress') {
+        return `A response has been submitted for this question in assignment attempt ${this.masteryAttempt.number}.`
+      }
+      if (this.masteryCanRetake) {
+        return `Assignment attempt ${this.masteryAttempt.number} is complete. Start a new attempt to answer this question again.`
+      }
+      return `Assignment attempt ${this.masteryAttempt.number} is complete. No additional assignment attempts are available.`
+    },
+    masteryAttemptResult () {
+      if (!this.masteryAttempt) return ''
+      return this.masteryAttempt.status === 'mastered'
+        ? `Assignment mastered in attempt ${this.masteryAttempt.number}.`
+        : `Attempt ${this.masteryAttempt.number} complete — ${this.masteryAttempt.score * 1}/${this.masteryAttempt.possible_score * 1} points.`
+    },
     allFlashcards () {
       if (this.assessmentType !== 'flashcard') return []
       return this.questions
@@ -5189,6 +5257,26 @@ export default {
       this.processingUpdatingQuestionView = false
     },
     uniqueId,
+    // Ask the server to replace current question state before loading the next assignment attempt.
+    async startMasteryRetake () {
+      if (!this.masteryCanRetake || this.startingMasteryRetake) return
+      this.startingMasteryRetake = true
+      try {
+        const { data } = await axios.post(`/api/assignments/${this.assignmentId}/mastery-attempts`, {
+          previous_attempt_id: this.masteryAttempt.id
+        })
+        this.masteryAttempt = data.mastery_attempt
+        window.location.reload()
+      } catch (error) {
+        const message = error.response && error.response.data && error.response.data.message
+          ? error.response.data.message
+          : 'A new assignment attempt could not be prepared. Please try again.'
+        this.$noty.error(message)
+        if (error.response && error.response.status === 409) window.location.reload()
+      } finally {
+        this.startingMasteryRetake = false
+      }
+    },
     hideModalSubmissionAccepted () {
       this.modalSubmissionAcceptedTitle = 'Submission Accepted'
       this.saveSubmissionConfirmation()
@@ -5297,6 +5385,12 @@ export default {
       return learningTreeId
     },
     async canSubmit () {
+      if (this.masteryRetakeEnabled && this.masteryAttempt && this.masteryAttempt.status !== 'in_progress') {
+        this.submitButtonActive = false
+        this.questionStatus = 'closed'
+        this.canViewHint = false
+        return
+      }
       try {
         const isForge = +this.isForge()
         const { data } = await axios.get(`/api/submissions/can-submit/assignment/${this.assignmentId}/question/${this.questions[this.currentPage - 1].id}/is-forge/${isForge}`)
@@ -5318,7 +5412,7 @@ export default {
       }
     },
     async saveSubmissionConfirmation () {
-      if (this.completedAllAssignmentQuestions) {
+      if (this.completedAllAssignmentQuestions && !this.masteryRetakeEnabled) {
         this.$bvModal.show('modal-assignment-completed')
       }
       try {
@@ -6606,6 +6700,9 @@ export default {
       }
 
       console.log(data)
+      if (data.mastery_attempt) {
+        this.masteryAttempt = data.mastery_attempt
+      }
       this.cacheKey++
       this.questions[this.currentPage - 1].submissions_array = []
       this.submissionDataType = ['success', 'info'].includes(data.type) ? data.type : 'danger'
@@ -7120,6 +7217,7 @@ export default {
         this.assignmentCanSubmitWork = assignment.can_submit_work
         this.canContactInstructorAutoGraded = assignment.can_contact_instructor_auto_graded
         this.algorithmicAssignment = Boolean(assignment.algorithmic)
+        this.masteryRetakeEnabled = Boolean(assignment.mastery_retake_enabled)
         this.canContactGrader = assignment.can_contact_grader
         this.betaAssignmentsExist = assignment.beta_assignments_exist
         this.isBetaAssignment = assignment.is_beta_assignment
@@ -7251,6 +7349,7 @@ export default {
         }
 
         this.questions = data.questions
+        this.masteryAttempt = data.mastery_attempt || null
         this.isInstructorLoggedInAsStudent = data.is_instructor_logged_in_as_student
         this.isInstructorWithAnonymousView = data.is_instructor_with_anonymous_view
         if (this.isInstructor()) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -500,6 +500,7 @@ Route::group(['middleware' => ['auth:api', 'analytics','rate.limit.by.user']], f
     Route::get('/sso/is-sso-user', 'Auth\SSOController@isSSOUser');
 
     Route::post('/assignments', 'AssignmentController@store');
+    Route::post('/assignments/{assignment}/mastery-attempts', 'MasteryAssignmentAttemptController@store');
     Route::post('/assignments/{assignment}/create-assignment-from-template', 'AssignmentController@createAssignmentFromTemplate');
     Route::patch('/assignments/{assignment}/show-assignment-statistics', 'AssignmentController@showAssignmentStatistics');
     Route::patch('/assignments/{assignment}/show-scores', 'AssignmentController@showScores');

--- a/tests/Feature/MasteryAssignmentAttemptTest.php
+++ b/tests/Feature/MasteryAssignmentAttemptTest.php
@@ -1,0 +1,666 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Assignment;
+use App\AssignmentSyncQuestion;
+use App\Course;
+use App\DataShop;
+use App\Enrollment;
+use App\Exceptions\MasteryRetakeConflictException;
+use App\Http\Requests\StoreAssignmentProperties;
+use App\Http\Requests\StoreSubmission;
+use App\MasteryAssignmentAttempt;
+use App\Question;
+use App\Score;
+use App\Section;
+use App\Services\MasteryAssignmentAttemptService;
+use App\Services\MasteryRetakeEligibility;
+use App\Submission;
+use App\Traits\Test;
+use App\User;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use Napp\Xray\Middleware\RequestTracing;
+use Tests\TestCase;
+
+class MasteryAssignmentAttemptTest extends TestCase
+{
+    use Test;
+
+    private $assignment;
+    private $course;
+    private $instructor;
+    private $student;
+    private $questions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(RequestTracing::class);
+
+        $this->instructor = factory(User::class)->create(['role' => 2]);
+        $this->student = factory(User::class)->create(['role' => 3]);
+        $this->course = factory(Course::class)->create(['user_id' => $this->instructor->id]);
+        $section = factory(Section::class)->create(['course_id' => $this->course->id]);
+        factory(Enrollment::class)->create([
+            'user_id' => $this->student->id,
+            'section_id' => $section->id,
+            'course_id' => $this->course->id
+        ]);
+        $this->assignment = factory(Assignment::class)->create([
+            'course_id' => $this->course->id,
+            'assessment_type' => 'real time',
+            'scoring_type' => 'p',
+            'algorithmic' => 1,
+            'number_of_allowed_attempts' => '1',
+            'number_of_allowed_attempts_penalty' => 0,
+            'number_of_randomized_assessments' => null,
+            'can_submit_work' => 0,
+            'hint_penalty' => 0,
+            'late_policy' => 'not accepted',
+            'mastery_retake_enabled' => 1,
+            'mastery_number_of_allowed_attempts' => 'unlimited'
+        ]);
+
+        $this->questions = collect([
+            factory(Question::class)->create(['technology' => 'webwork']),
+            factory(Question::class)->create(['technology' => 'webwork'])
+        ]);
+        foreach ($this->questions as $index => $question) {
+            DB::table('assignment_question')->insert([
+                'assignment_id' => $this->assignment->id,
+                'question_id' => $question->id,
+                'points' => 5,
+                'order' => $index + 1,
+                'open_ended_submission_type' => '0'
+            ]);
+        }
+        $this->assignUserToAssignment(
+            $this->assignment->id,
+            'course',
+            $this->course->id,
+            $this->student->id
+        );
+    }
+
+    /** @test */
+    public function eligibility_accepts_supported_questions_and_rejects_degenerate_points()
+    {
+        $eligibility = app(MasteryRetakeEligibility::class);
+        $this->assertTrue($eligibility->evaluate($this->assignment)->eligible());
+
+        $this->questions[0]->technology = 'imathas';
+        $this->questions[0]->save();
+        $this->assertTrue($eligibility->evaluate($this->assignment)->eligible());
+
+        $this->questions[0]->technology = 'qti';
+        $this->questions[0]->save();
+        $this->assertTrue($eligibility->evaluate($this->assignment)->eligible());
+
+        DB::table('assignment_question')
+            ->where('assignment_id', $this->assignment->id)
+            ->where('question_id', $this->questions[1]->id)
+            ->update(['points' => 0]);
+
+        $reason_codes = collect($eligibility->evaluate($this->assignment)->reasons())->pluck('code');
+        $this->assertTrue($reason_codes->contains('invalid_question_points'));
+    }
+
+    /** @test */
+    public function eligibility_rejects_unsupported_questions_and_anonymous_courses()
+    {
+        $eligibility = app(MasteryRetakeEligibility::class);
+
+        $this->questions[0]->technology = 'h5p';
+        $this->questions[0]->save();
+        $reason_codes = collect($eligibility->evaluate($this->assignment)->reasons())->pluck('code');
+        $this->assertTrue($reason_codes->contains('unsupported_question'));
+
+        $this->questions[0]->technology = 'webwork';
+        $this->questions[0]->save();
+        $this->course->anonymous_users = 1;
+        $this->course->save();
+        $this->assignment->unsetRelation('course');
+        $anonymous_reason = collect($eligibility->evaluate($this->assignment)->reasons())
+            ->firstWhere('code', 'anonymous_users');
+        $this->assertSame(
+            'Whole-assignment attempts are not available in courses that allow anonymous users.',
+            $anonymous_reason['message']
+        );
+    }
+
+    /** @test */
+    public function a_native_assignment_can_start_another_attempt_with_the_same_problem_versions()
+    {
+        $this->assignment->algorithmic = 0;
+        $this->assignment->save();
+        $fixed_variant = json_encode(['correct', 'incorrect']);
+        foreach ($this->questions as $question) {
+            $question->technology = 'qti';
+            $question->qti_json_type = 'question_json';
+            $question->qti_json = json_encode([
+                'questionType' => 'multiple_choice',
+                'randomizeOrder' => 'no',
+                'simpleChoice' => [
+                    ['identifier' => 'correct', 'correctResponse' => true],
+                    ['identifier' => 'incorrect', 'correctResponse' => false]
+                ]
+            ]);
+            $question->save();
+        }
+        $attempt = MasteryAssignmentAttempt::create([
+            'assignment_id' => $this->assignment->id,
+            'user_id' => $this->student->id,
+            'attempt_number' => 1,
+            'status' => MasteryAssignmentAttempt::STATUS_COMPLETED,
+            'question_ids' => $this->questions->pluck('id')->toArray(),
+            'variant_identifiers' => $this->questions->pluck('id')->mapWithKeys(function ($question_id) use ($fixed_variant) {
+                return [$question_id => $fixed_variant];
+            })->toArray(),
+            'question_results' => [],
+            'score' => 5,
+            'possible_score' => 10,
+            'completed_at' => now()
+        ]);
+
+        $next = app(MasteryAssignmentAttemptService::class)
+            ->startNextAttempt($this->assignment, $this->student, $attempt->id)['attempt'];
+
+        $this->assertSame(2, $next->attempt_number);
+        $this->assertSame(MasteryAssignmentAttempt::STATUS_IN_PROGRESS, $next->status);
+        foreach ($next->variant_identifiers as $variant) {
+            $this->assertSame($fixed_variant, $variant);
+        }
+    }
+
+    /** @test */
+    public function the_final_response_completes_an_authoritative_attempt_snapshot_and_updates_the_grade()
+    {
+        $service = app(MasteryAssignmentAttemptService::class);
+        $question_ids = $this->questions->pluck('id')->toArray();
+        $attempt = $service->getOrCreateForLaunch($this->assignment, $this->student, $question_ids);
+        $this->insertSeed($this->questions[0], 101);
+        $this->insertSeed($this->questions[1], 202);
+
+        $this->actingAs($this->student);
+        $partial = $this->storeWebworkSubmission($this->questions[0], $attempt, 1);
+        $this->assertSame(MasteryAssignmentAttempt::STATUS_IN_PROGRESS, $partial['mastery_attempt']['status']);
+        $this->assertDatabaseMissing('scores', [
+            'assignment_id' => $this->assignment->id,
+            'user_id' => $this->student->id
+        ]);
+
+        $completed = $this->storeWebworkSubmission($this->questions[1], $attempt, 0);
+
+        $snapshot = $attempt->fresh();
+        $this->assertSame(MasteryAssignmentAttempt::STATUS_COMPLETED, $snapshot->status);
+        $this->assertSame(MasteryAssignmentAttempt::STATUS_COMPLETED, $completed['mastery_attempt']['status']);
+        $this->assertSame($question_ids, $snapshot->question_ids);
+        $this->assertNotEmpty($snapshot->question_results[0]['submission']);
+        $this->assertSame('101', (string)$snapshot->question_results[0]['variant_identifier']);
+        $this->assertEquals(5, $snapshot->score);
+        $this->assertEquals(10, $snapshot->possible_score);
+        $this->assertDatabaseHas('scores', [
+            'assignment_id' => $this->assignment->id,
+            'user_id' => $this->student->id,
+            'score' => 5
+        ]);
+
+        $stale = $this->storeWebworkSubmission($this->questions[0], $attempt, 1);
+        $this->assertSame(409, $stale['status']);
+        $this->assertSame('stale_attempt', $stale['reason']);
+    }
+
+    /** @test */
+    public function a_duplicate_question_submission_is_rejected_while_the_attempt_remains_in_progress()
+    {
+        $service = app(MasteryAssignmentAttemptService::class);
+        $attempt = $service->getOrCreateForLaunch(
+            $this->assignment,
+            $this->student,
+            $this->questions->pluck('id')->toArray()
+        );
+
+        $this->actingAs($this->student);
+        $first = $this->storeWebworkSubmission($this->questions[0], $attempt, 1);
+        $duplicate = $this->storeWebworkSubmission($this->questions[0], $attempt, 0);
+
+        $this->assertSame(MasteryAssignmentAttempt::STATUS_IN_PROGRESS, $first['mastery_attempt']['status']);
+        $this->assertSame(409, $duplicate['status']);
+        $this->assertSame('duplicate_submission', $duplicate['reason']);
+        $this->assertDatabaseHas('submissions', [
+            'assignment_id' => $this->assignment->id,
+            'question_id' => $this->questions[0]->id,
+            'user_id' => $this->student->id,
+            'score' => 5,
+            'submission_count' => 1
+        ]);
+        $this->assertSame(MasteryAssignmentAttempt::STATUS_IN_PROGRESS, $attempt->fresh()->status);
+    }
+
+    /** @test */
+    public function a_retake_replaces_state_is_idempotent_and_retains_the_best_completed_score()
+    {
+        $service = app(MasteryAssignmentAttemptService::class);
+        $question_ids = $this->questions->pluck('id')->toArray();
+        $previous = MasteryAssignmentAttempt::create([
+            'assignment_id' => $this->assignment->id,
+            'user_id' => $this->student->id,
+            'attempt_number' => 1,
+            'status' => MasteryAssignmentAttempt::STATUS_COMPLETED,
+            'question_ids' => $question_ids,
+            'variant_identifiers' => [
+                $this->questions[0]->id => 100000,
+                $this->questions[1]->id => 100000
+            ],
+            'question_results' => [],
+            'score' => 8,
+            'possible_score' => 10,
+            'completed_at' => now()
+        ]);
+        foreach ($this->questions as $question) {
+            $this->insertSeed($question, 100000);
+            $this->insertSubmission($question, 'old response', 4, false);
+        }
+        DB::table('unconfirmed_submissions')->insert([
+            'assignment_id' => $this->assignment->id,
+            'question_id' => $this->questions[0]->id,
+            'user_id' => $this->student->id,
+            'submission' => '{}',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+        DB::table('submission_confirmations')->insert([
+            'assignment_id' => $this->assignment->id,
+            'question_id' => $this->questions[0]->id,
+            'user_id' => $this->student->id,
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+
+        $started = $service->startNextAttempt($this->assignment, $this->student, $previous->id);
+        $new_attempt = $started['attempt'];
+
+        $this->assertFalse($started['already_started']);
+        $this->assertSame(2, $new_attempt->attempt_number);
+        $this->assertSame(MasteryAssignmentAttempt::STATUS_IN_PROGRESS, $new_attempt->status);
+        $this->assertCount(2, $new_attempt->variant_identifiers);
+        foreach ($new_attempt->variant_identifiers as $variant) {
+            $this->assertNotSame('100000', (string)$variant);
+        }
+        $this->assertSame(0, DB::table('submissions')
+            ->where('assignment_id', $this->assignment->id)
+            ->where('user_id', $this->student->id)
+            ->count());
+        $this->assertSame(2, DB::table('seeds')
+            ->where('assignment_id', $this->assignment->id)
+            ->where('user_id', $this->student->id)
+            ->count());
+        $this->assertSame(0, DB::table('unconfirmed_submissions')
+            ->where('assignment_id', $this->assignment->id)
+            ->where('user_id', $this->student->id)
+            ->count());
+        $this->assertSame(0, DB::table('submission_confirmations')
+            ->where('assignment_id', $this->assignment->id)
+            ->where('user_id', $this->student->id)
+            ->count());
+
+        $repeated = $service->startNextAttempt($this->assignment, $this->student, $previous->id);
+        $this->assertTrue($repeated['already_started']);
+        $this->assertSame($new_attempt->id, $repeated['attempt']->id);
+
+        (new Score())->updateAssignmentScore($this->student->id, $this->assignment->id, false);
+        $this->assertDatabaseHas('scores', [
+            'assignment_id' => $this->assignment->id,
+            'user_id' => $this->student->id,
+            'score' => 8
+        ]);
+
+        $this->expectException(MasteryRetakeConflictException::class);
+        $service->validateSubmission($this->assignment, $this->student, $previous->id);
+    }
+
+    /** @test */
+    public function an_ordinary_assignment_keeps_the_existing_partial_score_behavior()
+    {
+        $this->assignment->mastery_retake_enabled = 0;
+        $this->assignment->save();
+        $this->insertSubmission($this->questions[0], 'legacy response', 5, true);
+
+        (new Score())->updateAssignmentScore($this->student->id, $this->assignment->id, false);
+
+        $this->assertDatabaseHas('scores', [
+            'assignment_id' => $this->assignment->id,
+            'user_id' => $this->student->id,
+            'score' => 5
+        ]);
+        $this->assertSame(0, MasteryAssignmentAttempt::where('assignment_id', $this->assignment->id)->count());
+    }
+
+    /** @test */
+    public function an_all_correct_attempt_can_be_restarted_when_assignment_attempts_are_unlimited()
+    {
+        $service = app(MasteryAssignmentAttemptService::class);
+        $attempt = $service->getOrCreateForLaunch(
+            $this->assignment,
+            $this->student,
+            $this->questions->pluck('id')->toArray()
+        );
+        foreach ($this->questions as $index => $question) {
+            $this->insertSeed($question, 300 + $index);
+            $this->insertSubmission($question, "correct response {$index}", 5, true);
+        }
+
+        $completed = $service->completeIfReady($this->assignment, $this->student, $attempt);
+
+        $this->assertTrue($completed['completed']);
+        $this->assertSame(MasteryAssignmentAttempt::STATUS_MASTERED, $completed['attempt']->status);
+        $this->assertTrue($service->payload($completed['attempt'])['can_retake']);
+
+        $retake = $service->startNextAttempt($this->assignment, $this->student, $attempt->id);
+        $this->assertSame(2, $retake['attempt']->attempt_number);
+        $this->assertSame(MasteryAssignmentAttempt::STATUS_IN_PROGRESS, $retake['attempt']->status);
+    }
+
+    /** @test */
+    public function a_finite_assignment_attempt_limit_blocks_another_retake()
+    {
+        $this->assignment->mastery_number_of_allowed_attempts = '2';
+        $this->assignment->save();
+        $attempt = MasteryAssignmentAttempt::create([
+            'assignment_id' => $this->assignment->id,
+            'user_id' => $this->student->id,
+            'attempt_number' => 2,
+            'status' => MasteryAssignmentAttempt::STATUS_MASTERED,
+            'question_ids' => $this->questions->pluck('id')->toArray(),
+            'variant_identifiers' => [],
+            'question_results' => [],
+            'score' => 10,
+            'possible_score' => 10,
+            'completed_at' => now()
+        ]);
+
+        $service = app(MasteryAssignmentAttemptService::class);
+        $this->assertFalse($service->payload($attempt)['can_retake']);
+
+        try {
+            $service->startNextAttempt($this->assignment, $this->student, $attempt->id);
+            $this->fail('The configured assignment-attempt limit should prevent another retake.');
+        } catch (MasteryRetakeConflictException $e) {
+            $this->assertSame('attempt_limit_reached', $e->reason());
+        }
+    }
+
+    /** @test */
+    public function a_later_lower_completed_attempt_does_not_reduce_the_best_score()
+    {
+        $question_ids = $this->questions->pluck('id')->toArray();
+        foreach ([1 => 8, 2 => 3] as $attempt_number => $attempt_score) {
+            MasteryAssignmentAttempt::create([
+                'assignment_id' => $this->assignment->id,
+                'user_id' => $this->student->id,
+                'attempt_number' => $attempt_number,
+                'status' => MasteryAssignmentAttempt::STATUS_COMPLETED,
+                'question_ids' => $question_ids,
+                'variant_identifiers' => [],
+                'question_results' => [],
+                'score' => $attempt_score,
+                'possible_score' => 10,
+                'completed_at' => now()
+            ]);
+        }
+
+        (new Score())->updateAssignmentScore($this->student->id, $this->assignment->id, false);
+
+        $this->assertDatabaseHas('scores', [
+            'assignment_id' => $this->assignment->id,
+            'user_id' => $this->student->id,
+            'score' => 8
+        ]);
+    }
+
+    /** @test */
+    public function instructors_can_preview_without_a_mastery_attempt_identifier()
+    {
+        $this->actingAs($this->instructor);
+        $response = $this->storeWebworkSubmission($this->questions[0], null, 1);
+
+        $this->assertSame('success', $response['type']);
+        $this->assertArrayNotHasKey('reason', $response);
+    }
+
+    /** @test */
+    public function only_an_enrolled_student_can_start_the_next_attempt()
+    {
+        $previous = $this->completedAttempt();
+
+        $this->actingAs($this->student)
+            ->postJson("/api/assignments/{$this->assignment->id}/mastery-attempts", [
+                'previous_attempt_id' => $previous->id
+            ])
+            ->assertStatus(200)
+            ->assertJson(['type' => 'success']);
+
+        $outsider = factory(User::class)->create(['role' => 3]);
+        $this->actingAs($outsider)
+            ->postJson("/api/assignments/{$this->assignment->id}/mastery-attempts", [
+                'previous_attempt_id' => $previous->id
+            ])
+            ->assertStatus(403)
+            ->assertJson(['reason' => 'not_authorized']);
+    }
+
+    /** @test */
+    public function mastery_cannot_be_enabled_after_ordinary_student_work_exists()
+    {
+        $this->assignment->mastery_retake_enabled = 0;
+        $this->assignment->save();
+        $this->insertSubmission($this->questions[0], 'legacy response', 5, true);
+
+        $request = StoreAssignmentProperties::create('/', 'PATCH', [
+            'mastery_retake_enabled' => 1
+        ]);
+        $route = new Route(['PATCH'], '/', []);
+        $route->bind($request);
+        $route->setParameter('assignment', $this->assignment);
+        $request->setRouteResolver(function () use ($route) {
+            return $route;
+        });
+        $validator = Validator::make($request->all(), []);
+        $request->withValidator($validator);
+
+        $this->assertTrue($validator->fails());
+        $this->assertSame(
+            'Whole-assignment attempts cannot be enabled after student work exists.',
+            $validator->errors()->first('mastery_retake_enabled')
+        );
+    }
+
+    /** @test */
+    public function completed_attempts_can_be_reopened_after_assignment_eligibility_changes()
+    {
+        $attempt = $this->completedAttempt();
+        DB::table('assignment_question')
+            ->where('assignment_id', $this->assignment->id)
+            ->where('question_id', $this->questions[0]->id)
+            ->update(['points' => 0]);
+
+        $reopened = app(MasteryAssignmentAttemptService::class)->getOrCreateForLaunch(
+            $this->assignment,
+            $this->student,
+            $this->questions->pluck('id')->toArray()
+        );
+
+        $this->assertSame($attempt->id, $reopened->id);
+        $this->assertSame(MasteryAssignmentAttempt::STATUS_COMPLETED, $reopened->status);
+    }
+
+    /** @test */
+    public function question_points_can_be_changed_before_a_real_student_attempt_starts()
+    {
+        $this->actingAs($this->instructor)
+            ->patchJson(
+                "/api/assignments/{$this->assignment->id}/questions/{$this->questions[0]->id}/update-points",
+                ['points' => 20]
+            )
+            ->assertJson(['type' => 'success']);
+
+        $this->assertDatabaseHas('assignment_question', [
+            'assignment_id' => $this->assignment->id,
+            'question_id' => $this->questions[0]->id,
+            'points' => 20
+        ]);
+    }
+
+    /** @test */
+    public function question_points_are_locked_after_a_real_student_attempt_starts()
+    {
+        $this->completedAttempt();
+
+        $this->actingAs($this->instructor)
+            ->patchJson(
+                "/api/assignments/{$this->assignment->id}/questions/{$this->questions[0]->id}/update-points",
+                ['points' => 20]
+            )
+            ->assertJson([
+                'message' => 'This cannot be updated since students have already submitted responses to this assignment.'
+            ]);
+
+        $this->assertDatabaseHas('assignment_question', [
+            'assignment_id' => $this->assignment->id,
+            'question_id' => $this->questions[0]->id,
+            'points' => 5
+        ]);
+    }
+
+    /** @test */
+    public function question_response_settings_are_locked_after_a_real_student_attempt_starts()
+    {
+        $this->completedAttempt();
+
+        $this->actingAs($this->instructor)
+            ->patchJson(
+                "/api/assignments/{$this->assignment->id}/questions/{$this->questions[0]->id}/update-open-ended-submission-type",
+                ['open_ended_submission_type' => 'file']
+            )
+            ->assertJson([
+                'message' => 'Question response settings cannot be changed after a student has started a whole-assignment attempt.'
+            ]);
+
+        $this->assertDatabaseHas('assignment_question', [
+            'assignment_id' => $this->assignment->id,
+            'question_id' => $this->questions[0]->id,
+            'open_ended_submission_type' => '0'
+        ]);
+    }
+
+    /** @test */
+    public function a_fake_student_gets_a_new_initial_attempt_after_question_membership_changes()
+    {
+        $fake_student = factory(User::class)->create([
+            'role' => 3,
+            'fake_student' => 1
+        ]);
+        $service = app(MasteryAssignmentAttemptService::class);
+        $first = $service->getOrCreateForLaunch(
+            $this->assignment,
+            $fake_student,
+            $this->questions->pluck('id')->toArray()
+        );
+        DB::table('assignment_question')
+            ->where('assignment_id', $this->assignment->id)
+            ->where('question_id', $this->questions[1]->id)
+            ->delete();
+
+        $replacement = $service->getOrCreateForLaunch(
+            $this->assignment,
+            $fake_student,
+            [$this->questions[0]->id]
+        );
+
+        $this->assertNotSame($first->id, $replacement->id);
+        $this->assertSame(1, $replacement->attempt_number);
+        $this->assertSame([$this->questions[0]->id], $replacement->question_ids);
+    }
+
+    private function completedAttempt(): MasteryAssignmentAttempt
+    {
+        return MasteryAssignmentAttempt::create([
+            'assignment_id' => $this->assignment->id,
+            'user_id' => $this->student->id,
+            'attempt_number' => 1,
+            'status' => MasteryAssignmentAttempt::STATUS_COMPLETED,
+            'question_ids' => $this->questions->pluck('id')->toArray(),
+            'variant_identifiers' => $this->questions->pluck('id')->mapWithKeys(function ($question_id) {
+                return [$question_id => 100000];
+            })->toArray(),
+            'question_results' => [],
+            'score' => 5,
+            'possible_score' => 10,
+            'completed_at' => now()
+        ]);
+    }
+
+    private function storeWebworkSubmission(Question $question, ?MasteryAssignmentAttempt $attempt, float $score): array
+    {
+        $request = StoreSubmission::create('/', 'POST', [
+            'assignment_id' => $this->assignment->id,
+            'question_id' => $question->id,
+            'technology' => 'webwork',
+            'mastery_attempt_id' => $attempt ? $attempt->id : null,
+            'submission' => (object)[
+                'score' => (object)[
+                    'result' => $score,
+                    'answers' => [
+                        ['score' => $score, 'weight' => 100]
+                    ]
+                ]
+            ]
+        ]);
+        $route = new Route(['POST'], '/', []);
+        $route->bind($request);
+        $request->setRouteResolver(function () use ($route) {
+            return $route;
+        });
+        $request->setUserResolver(function () {
+            return $this->student;
+        });
+        app()->instance('request', $request);
+
+        return (new Submission())->store(
+            $request,
+            new Submission(),
+            new Assignment(),
+            new Score(),
+            new DataShop(),
+            new AssignmentSyncQuestion()
+        );
+    }
+
+    private function insertSubmission(Question $question, string $response, float $score, bool $correct): void
+    {
+        Submission::create([
+            'assignment_id' => $this->assignment->id,
+            'question_id' => $question->id,
+            'user_id' => $this->student->id,
+            'submission' => $response,
+            'score' => $score,
+            'submission_count' => 1,
+            'answered_correctly_at_least_once' => $correct
+        ]);
+    }
+
+    private function insertSeed(Question $question, int $seed): void
+    {
+        DB::table('seeds')->insert([
+            'assignment_id' => $this->assignment->id,
+            'question_id' => $question->id,
+            'user_id' => $this->student->id,
+            'seed' => $seed,
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds an opt-in whole-assignment attempt policy to ADAPT.

Instructors may retain the existing per-question model or require students to answer every question as one complete attempt.    
Attempts can be limited or unlimited, and the highest completed score is retained.

## Pedagogical purpose

The goal is to support mastery-based practice. Students complete the entire assignment, review immediate feedback, and then     
start a new attempt. When algorithmic variation is enabled, WeBWorK and IMathAS questions can provide fresh problem variants,   
encouraging students to learn the concepts rather than memorize answers.

## Implementation

This PR includes:

- Instructor controls for selecting the attempt policy.
- Student attempt status, completion feedback, and retry controls.
- Additive database migrations and attempt-history records.
- Protection against duplicate and stale requests.
- Focused Feature-test coverage.

The feature is disabled by default, so existing assignments retain their current behavior. Native, WeBWorK, and IMathAS         
questions are supported; H5P and open-ended questions are not.

## Screenshots

**Instructor configuration:** Select whole-assignment attempts and set the number of allowed attempts.

<img width="766" height="425" alt="Whole-assignment attempt policy settings" src="https://github.com/user-attachments/
assets/701a57b5-4032-4f5a-97fb-e5b62ef754e8" />

**Attempt in progress:** Students see the current attempt and remaining attempts.

<img width="1280" height="330" alt="Whole-assignment attempt in progress" src="https://github.com/user-attachments/assets/      
f8a96814-be1e-449e-9a4d-f2e33715c326" />

**Completed attempt:** Students see their score and can start another attempt.

<img width="1280" height="330" alt="Completed whole-assignment attempt" src="https://github.com/user-attachments/
assets/1b4f09ac-01ac-44d8-ad6f-2c6cd10e2f29" />

**Mastered assignment:** The completed native-question workflow retains the student’s highest score.

<img width="1280" height="800" alt="Mastered native-question assignment" src="https://github.com/user-attachments/assets/       
ac4f6172-3531-44a9-842b-361a1e2ae59b" />

## Testing and feedback

I tested the instructor and student workflows locally in Docker.

Please feel free to reach out with questions or concerns. I will try to attend LibreTexts Office Hours on Tuesday and would be  
happy to demonstrate the workflow or discuss the implementation.

